### PR TITLE
Fix GitHub Actions workflow error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       
       - name: Build
         run: npm run build


### PR DESCRIPTION
## 問題

`package-lock.json` が存在しないため、GitHub Actionsで以下のエラーが発生していました：
```
Error: Dependencies lock file is not found in /home/runner/work/hrstsh.github.io/hrstsh.github.io. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

## 修正内容

- `cache: 'npm'` を削除（lock fileがないためキャッシュ不要）
- `npm ci` を `npm install` に変更

## 確認

このPRをマージすると、GitHub Actionsが正常に実行されるようになります。