### PR TITLE
Fix HTML entity escape issue in git alias

### DIFF
--- a/src/pages/tools/git-cheatsheet.astro
+++ b/src/pages/tools/git-cheatsheet.astro
@@ -137,7 +137,7 @@ git config --global alias.ci commit</code></pre>
 
           <h4>便利なエイリアス</h4>
           <pre><code># 見やすいログ表示
-git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)&lt;%an&gt;%Creset' --abbrev-commit"
 
 # 最後のコミットを表示
 git config --global alias.last 'log -1 HEAD'


### PR DESCRIPTION
## 問題

ビルド時に以下のTypeScriptパースエラーが発生していました：

```
src/pages/tools/git-cheatsheet.astro:140:126 - error ts(1003): Identifier expected.
```

## 原因

git log aliasの中で使用していた`<%an>`（コミット作成者名）の部分が、Astroファイル内でHTMLタグとして解釈されてしまいました。

## 修正内容

`<%an>`を`&lt;%an&gt;`にHTMLエンティティエスケープしました。

**変更前:**
```
git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
```

**変更後:**
```
git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)&lt;%an&gt;%Creset' --abbrev-commit"
```

## 確認

この修正により、ビルドが正常に通るようになります。HTMLとして表示される際には正しく`<`と`>`として表示されます。