### PR TITLE
Add detailed content to tips sections (17-20)

### DIFF
--- a/src/pages/tools/git-cheatsheet/tips.astro
+++ b/src/pages/tools/git-cheatsheet/tips.astro
@@ -229,6 +229,9 @@ echo "local-only-file.txt" &gt;&gt; .git/info/exclude</code></pre>
         </div>
 
         <h3>便利なリソース</h3>
+        <p>
+          .gitignore のテンプレートを生成するサービスとリポジトリです。
+        </p>
         <div class="command-block">
           <pre><code># gitignore.io - 言語/IDE別の.gitignoreテンプレート生成
 # https://www.toptal.com/developers/gitignore
@@ -577,6 +580,9 @@ git config core.untrackedcache true</code></pre>
         </div>
 
         <h3>セキュリティベストプラクティス</h3>
+        <p>
+          機密情報の扱いとコミット署名の基本です。
+        </p>
         <div class="command-block">
           <pre><code># 機密情報をコミットしない
 # - .envファイルは.gitignoreに追加
@@ -725,6 +731,9 @@ git config --global init.defaultBranch main</code></pre>
         </div>
 
         <h3>便利なGitHub機能</h3>
+        <p>
+          Web 上での編集やバッジ表示など、よく使う機能の例です。
+        </p>
         <div class="command-block">
           <h4>GitHub上でファイルを直接編集</h4>
           <pre><code># URLに.github.devを付けるor 「.」キーを押す
@@ -753,10 +762,13 @@ https://github.com/user/repo/blob/main/file.js#L10-L20</code></pre>
         </div>
 
         <h3>ベストプラクティス</h3>
+        <p>
+          PR・Issue・リポジトリ運用のポイントです。
+        </p>
         <div class="command-block">
           <pre><code># Pull Requestのベストプラクティス
 
-1. 小さくkeep（変更行数を少なく）
+1. 小さく保つ（変更行数を少なく）
 2. 明確なタイトルと説明
 3. 関連Issueをリンク
 4. レビューアを指定

--- a/src/pages/tools/git-cheatsheet/tips.astro
+++ b/src/pages/tools/git-cheatsheet/tips.astro
@@ -19,7 +19,226 @@ import Navigation from '../../../components/git-cheatsheet/Navigation.astro';
           バージョン管理から除外するファイルを指定する.gitignoreファイルの設定方法。
           言語やフレームワーク別の一般的なパターンも紹介します。
         </p>
-        <p class="note">※ 詳細なコマンド例は次の更新で追加されます。</p>
+
+        <h3>.gitignoreの基本</h3>
+        <p>
+          プロジェクトルートに.gitignoreファイルを作成し、除外したいファイルのパターンを記述します。
+        </p>
+        <div class="command-block">
+          <h4>基本的なパターン</h4>
+          <pre><code># .gitignoreファイルの例
+
+# コメントは#で開始
+
+# 特定のファイルを無視
+secrets.txt
+config.local.js
+
+# 特定のディレクトリを無視（末尾に/）
+node_modules/
+.cache/
+dist/
+
+# ワイルドカード
+*.log
+*.tmp
+*.swp
+
+# パスを指定
+path/to/file.txt
+path/to/directory/
+
+# 再帰的に無視（**）
+**/temp/
+**/*.backup
+
+# 否定（!で例外を指定）
+*.log
+!important.log  # important.logは追跡する</code></pre>
+
+          <h4>パターンのルール</h4>
+          <pre><code># 空白行と#コメントは無視される
+
+# 末尾のスペースは無視される（\でエスケープ）
+file.txt   # スペースは無視
+file.txt\  # 末尾スペースを含む
+
+# /で始まるパターンはルートからのパス
+/file.txt       # ルートのfile.txtのみ
+file.txt        # 全てのfile.txt
+
+# /で終わるパターンはディレクトリのみ
+directory/      # directoryディレクトリとその中身
+
+# **は任意のディレクトリ階層
+**/logs/        # すべてのlogsディレクトリ
+docs/**/*.pdf   # docs以下の全PDF</code></pre>
+        </div>
+
+        <h3>言語・フレームワーク別パターン</h3>
+        <p>
+          一般的な開発環境で除外すべきファイルのパターン例です。
+        </p>
+        <div class="command-block">
+          <h4>Node.js / JavaScript</h4>
+          <pre><code># 依存関係
+node_modules/
+
+# ビルド成果物
+dist/
+build/
+out/
+.next/
+.nuxt/
+
+# 環境変数
+.env
+.env.local
+.env.*.local
+
+# ログファイル
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# キャッシュ
+.cache/
+.parcel-cache/
+.eslintcache
+
+# IDE / エディタ
+.vscode/
+.idea/
+*.swp
+*.swo
+*~</code></pre>
+
+          <h4>Python</h4>
+          <pre><code># バイトコード
+__pycache__/
+*.py[cod]
+*$py.class
+
+# 仮想環境
+venv/
+env/
+ENV/
+.venv
+
+# 配布 / パッケージング
+build/
+develop-eggs/
+dist/
+*.egg-info/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pytest
+.pytest_cache/
+.coverage
+
+# mypy
+.mypy_cache/</code></pre>
+
+          <h4>Java</h4>
+          <pre><code># コンパイル済みクラス
+*.class
+
+# パッケージファイル
+*.jar
+*.war
+*.ear
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+
+# Gradle
+.gradle/
+build/
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+
+# Eclipse
+.classpath
+.project
+.settings/</code></pre>
+
+          <h4>汎用的なパターン</h4>
+          <pre><code># OS生成ファイル
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# バックアップファイル
+*.bak
+*.backup
+*~
+
+# ログファイル
+*.log
+logs/
+
+# 一時ファイル
+*.tmp
+*.temp
+tmp/
+temp/
+
+# 機密情報
+.env
+secrets/
+*.key
+*.pem
+credentials.json</code></pre>
+        </div>
+
+        <h3>.gitignoreの管理</h3>
+        <p>
+          .gitignoreファイルを効果的に管理する方法です。
+        </p>
+        <div class="command-block">
+          <pre><code># .gitignoreを作成してコミット
+touch .gitignore
+# ファイルを編集
+git add .gitignore
+git commit -m "Add .gitignore"
+
+# 既に追跡されているファイルを削除（ローカルファイルは残す）
+git rm --cached file.txt
+git rm --cached -r directory/
+
+# .gitignoreを追加後、既存ファイルを一括削除
+git rm -r --cached .
+git add .
+git commit -m "Apply .gitignore to existing files"
+
+# 特定のファイルが無視されるかテスト
+git check-ignore -v file.txt
+
+# グローバル.gitignore（ユーザー全体に適用）
+git config --global core.excludesfile ~/.gitignore_global
+
+# ローカルのみの除外（.git/info/exclude）
+echo "local-only-file.txt" &gt;&gt; .git/info/exclude</code></pre>
+        </div>
+
+        <h3>便利なリソース</h3>
+        <div class="command-block">
+          <pre><code># gitignore.io - 言語/IDE別の.gitignoreテンプレート生成
+# https://www.toptal.com/developers/gitignore
+
+# GitHubの.gitignoreテンプレート集
+# https://github.com/github/gitignore
+
+# コマンドラインで生成（gitignore.io API）
+curl -L https://www.toptal.com/developers/gitignore/api/node,react,vscode &gt; .gitignore</code></pre>
+        </div>
       </section>
 
       <section id="hooks">
@@ -28,7 +247,174 @@ import Navigation from '../../../components/git-cheatsheet/Navigation.astro';
           特定のGitイベント発生時に自動実行されるスクリプト、Git Hooksの使い方。
           コード品質の維持や自動化に役立ちます。
         </p>
-        <p class="note">※ 詳細なコマンド例は次の更新で追加されます。</p>
+
+        <h3>Hooksの種類と場所</h3>
+        <p>
+          Git Hooksは.git/hooks/ディレクトリに配置されます。
+        </p>
+        <div class="command-block">
+          <h4>クライアント側フック</h4>
+          <pre><code># .git/hooks/ディレクトリに配置
+
+pre-commit         # コミット前に実行
+prepare-commit-msg # コミットメッセージエディタ起動前
+commit-msg         # コミットメッセージ検証
+post-commit        # コミット後に実行
+pre-rebase         # rebase前に実行
+post-checkout      # checkout後に実行
+post-merge         # マージ後に実行
+pre-push           # push前に実行
+pre-auto-gc        # 自動gc前に実行</code></pre>
+
+          <h4>サーバー側フック</h4>
+          <pre><code>pre-receive   # push受信前
+update        # ブランチ更新時
+post-receive  # push受信後
+post-update   # ブランチ更新後</code></pre>
+        </div>
+
+        <h3>Hooksの作成例</h3>
+        <p>
+          実際に役立つHooksの実装例です。
+        </p>
+        <div class="command-block">
+          <h4>pre-commit: コード検証</h4>
+          <pre><code>#!/bin/sh
+# .git/hooks/pre-commit
+
+# ESLintでJavaScriptをチェック
+echo "Running ESLint..."
+npm run lint
+if [ $? -ne 0 ]; then
+  echo "❌ ESLint failed. Please fix errors before committing."
+  exit 1
+fi
+
+# Prettierでフォーマットチェック
+echo "Checking code formatting..."
+npm run format:check
+if [ $? -ne 0 ]; then
+  echo "❌ Code formatting issues found. Run 'npm run format' to fix."
+  exit 1
+fi
+
+echo "✅ All checks passed!"
+exit 0</code></pre>
+
+          <h4>commit-msg: コミットメッセージ検証</h4>
+          <pre><code>#!/bin/sh
+# .git/hooks/commit-msg
+
+COMMIT_MSG_FILE=$1
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# Conventional Commits形式を強制
+PATTERN="^(feat|fix|docs|style|refactor|test|chore)(\\(.+\\))?: .{1,}"
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+  echo "❌ Invalid commit message format!"
+  echo ""
+  echo "Format: type(scope): description"
+  echo ""
+  echo "Types:"
+  echo "  feat:     New feature"
+  echo "  fix:      Bug fix"
+  echo "  docs:     Documentation changes"
+  echo "  style:    Code style changes (formatting, etc.)"
+  echo "  refactor: Code refactoring"
+  echo "  test:     Test changes"
+  echo "  chore:    Build/tooling changes"
+  echo ""
+  echo "Example: feat(auth): add login functionality"
+  exit 1
+fi
+
+exit 0</code></pre>
+
+          <h4>pre-push: テスト実行</h4>
+          <pre><code>#!/bin/sh
+# .git/hooks/pre-push
+
+# テストを実行
+echo "Running tests..."
+npm test
+if [ $? -ne 0 ]; then
+  echo "❌ Tests failed. Push aborted."
+  exit 1
+fi
+
+# mainブランチへの直接pushを禁止
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  echo "❌ Direct push to $BRANCH is not allowed!"
+  echo "Please create a feature branch and open a PR."
+  exit 1
+fi
+
+echo "✅ Pre-push checks passed!"
+exit 0</code></pre>
+        </div>
+
+        <h3>Hooksの有効化</h3>
+        <p>
+          Hooksスクリプトを有効化する手順です。
+        </p>
+        <div class="command-block">
+          <pre><code># Hookスクリプトを作成
+touch .git/hooks/pre-commit
+
+# 実行権限を付与
+chmod +x .git/hooks/pre-commit
+
+# Hookをテスト
+.git/hooks/pre-commit
+
+# Hookを一時的にスキップ
+git commit --no-verify
+git commit -n
+
+git push --no-verify
+git push -n</code></pre>
+        </div>
+
+        <h3>HuskyでHooksを管理</h3>
+        <p>
+          Huskyを使用すると、Hooksをチーム全体で共有しやすくなります。
+        </p>
+        <div class="command-block">
+          <pre><code># Huskyのインストール（Node.jsプロジェクト）
+npm install --save-dev husky
+npx husky init
+
+# Hookを追加
+npx husky add .husky/pre-commit "npm test"
+npx husky add .husky/commit-msg 'npx --no -- commitlint --edit $1'
+
+# package.jsonに設定
+{
+  "scripts": {
+    "prepare": "husky install"
+  }
+}
+
+# lint-stagedと組み合わせてステージングされたファイルのみlint
+npm install --save-dev lint-staged
+
+# package.json
+{
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
+    "*.{css,scss}": ["prettier --write"],
+    "*.{json,md}": ["prettier --write"]
+  }
+}
+
+# .husky/pre-commit
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged</code></pre>
+        </div>
       </section>
 
       <section id="practical-tips">
@@ -37,7 +423,177 @@ import Navigation from '../../../components/git-cheatsheet/Navigation.astro';
           実際の開発現場で役立つベストプラクティスやトラブルシューティング。
           コミットメッセージの書き方、ブランチ戦略などを紹介します。
         </p>
-        <p class="note">※ 詳細なコマンド例は次の更新で追加されます。</p>
+
+        <h3>コミットメッセージのベストプラクティス</h3>
+        <p>
+          良いコミットメッセージは、プロジェクトの履歴を理解しやすくします。
+        </p>
+        <div class="command-block">
+          <h4>Conventional Commits</h4>
+          <pre><code># 形式
+type(scope): subject
+
+body
+
+footer
+
+# 例
+feat(auth): add JWT authentication
+
+Implement JWT-based authentication system:
+- Add login endpoint
+- Create token verification middleware
+- Update user model
+
+Closes #123
+
+# 主なtype
+feat:     新機能
+fix:      バグ修正
+docs:     ドキュメントのみの変更
+style:    コードの意味に影響しない変更（空白、フォーマットなど）
+refactor: リファクタリング
+test:     テストの追加・修正
+chore:    ビルドプロセスやツールの変更
+perf:     パフォーマンス改善
+ci:       CIの変更
+build:    ビルドシステムの変更
+revert:   以前のコミットを元に戻す</code></pre>
+
+          <h4>良いコミットメッセージのルール</h4>
+          <pre><code># ✅ 良い例
+feat: add user registration form
+fix: resolve memory leak in data processing
+docs: update API documentation for v2.0
+
+# ❌ 悪い例
+fixed stuff
+update
+WIP
+aaa
+
+# ルール
+1. 一行目は50文字以内
+2. 一行目と本文は空行で区切る
+3. 一行目は命令形（"Add"、"Fix"など）
+4. 本文は72文字で改行
+5. 「Why」を説明（「What」だけでなく）
+6. Issue番号を参照
+7. 破壊的変更はBREAKING CHANGE:を明記</code></pre>
+        </div>
+
+        <h3>ブランチ戦略</h3>
+        <p>
+          プロジェクトの規模やチームに合わせたブランチ戦略を選択しましょう。
+        </p>
+        <div class="command-block">
+          <h4>GitHub Flow（シンプル）</h4>
+          <pre><code># 小規模チーム、高頻度デプロイに適している
+
+1. mainブランチは常にデプロイ可能状態
+2. 新機能はmainからブランチを作成
+3. 定期的にpushしてバックアップ
+4. Pull Requestでレビュー
+5. mainにマージ後、すぐにデプロイ</code></pre>
+
+          <h4>Git Flow（複雑）</h4>
+          <pre><code># 大規模プロジェクト、計画的リリースに適している
+
+メインブランチ:
+- main/master: 本番環境のコード
+- develop: 開発中のコード
+
+サポートブランチ:
+- feature/*: 新機能開発
+- release/*: リリース準備
+- hotfix/*: 緊急修正</code></pre>
+
+          <h4>Trunk-Based Development</h4>
+          <pre><code># 高頻度インテグレーション
+
+1. メインブランチ（trunk）に直接コミット
+2. ブランチは短命（1日以内）
+3. Feature Flagで未完成機能を管理
+4. 自動テストが充実</code></pre>
+        </div>
+
+        <h3>トラブルシューティング</h3>
+        <p>
+          よくある問題とその解決方法です。
+        </p>
+        <div class="command-block">
+          <h4>間違ったファイルをコミットしてしまった</h4>
+          <pre><code># 直前のコミットからファイルを削除
+git rm --cached unwanted-file.txt
+git commit --amend --no-edit
+
+# 過去のコミットから削除（履歴を書き換え）
+git filter-branch --tree-filter 'rm -f unwanted-file.txt' HEAD</code></pre>
+
+          <h4>大きなファイルを誤ってコミット</h4>
+          <pre><code># BFG Repo-Cleanerを使用（推奨）
+bfg --delete-files large-file.zip
+git reflog expire --expire=now --all
+git gc --prune=now --aggressive
+
+# Git LFSに移行
+git lfs install
+git lfs track "*.zip"
+git add .gitattributes
+git add large-file.zip
+git commit --amend</code></pre>
+
+          <h4>コミットを間違ったブランチにしてしまった</h4>
+          <pre><code># 1. 正しいブランチを作成
+git branch correct-branch
+
+# 2. 間違ったブランチをリセット
+git reset --hard HEAD~1
+
+# 3. 正しいブランチに切り替え
+git checkout correct-branch</code></pre>
+        </div>
+
+        <h3>パフォーマンス最適化</h3>
+        <p>
+          大規模リポジトリでのGitパフォーマンスを改善する方法です。
+        </p>
+        <div class="command-block">
+          <pre><code># 浅いクローン（履歴を制限）
+git clone --depth 1 https://github.com/user/repo.git
+
+# 部分クローン（特定フォルダのみ）
+git clone --filter=blob:none --sparse https://github.com/user/repo.git
+cd repo
+git sparse-checkout init --cone
+git sparse-checkout set path/to/needed/folder
+
+# ガベージコレクションで最適化
+git gc --aggressive --prune=now
+
+# ファイルシステムモニタを有効化（大規模リポジトリ）
+git config core.fsmonitor true
+git config core.untrackedcache true</code></pre>
+        </div>
+
+        <h3>セキュリティベストプラクティス</h3>
+        <div class="command-block">
+          <pre><code># 機密情報をコミットしない
+# - .envファイルは.gitignoreに追加
+# - APIキーやパスワードをハードコードしない
+# - 秘密鍵（.key, .pem）をコミットしない
+
+# コミットに署名（GPG）
+git config --global user.signingkey YOUR_GPG_KEY_ID
+git config --global commit.gpgsign true
+git commit -S -m "Signed commit"
+
+# 機密情報を間違ってコミットした場合
+# 1. 直ちに.gitignoreに追加
+# 2. 履歴から完全に削除
+# 3. キー/パスワードを変更
+# 4. リモートにプッシュ済みなら報告</code></pre>
+        </div>
       </section>
 
       <section id="github">
@@ -46,7 +602,184 @@ import Navigation from '../../../components/git-cheatsheet/Navigation.astro';
           GitHub CLIやPull Requestの作成など、GitHub固有の機能とGitコマンドの組み合わせ。
           現代的な開発フローで必須の知識です。
         </p>
-        <p class="note">※ 詳細なコマンド例は次の更新で追加されます。</p>
+
+        <h3>GitHub CLI (gh)</h3>
+        <p>
+          GitHub CLIを使用すると、コマンドラインからGitHubの操作ができます。
+        </p>
+        <div class="command-block">
+          <h4>インストール</h4>
+          <pre><code># macOS (Homebrew)
+brew install gh
+
+# Windows (Scoop)
+scoop install gh
+
+# Linux (Debian/Ubuntu)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list &gt; /dev/null
+sudo apt update
+sudo apt install gh
+
+# 認証
+gh auth login</code></pre>
+
+          <h4>Pull Request操作</h4>
+          <pre><code># PRを作成
+gh pr create --title "Add new feature" --body "Description of changes"
+
+# 対話形式でPR作成
+gh pr create
+
+# PRの一覧
+gh pr list
+
+# PRをチェックアウト
+gh pr checkout 123
+
+# PRの詳細を表示
+gh pr view 123
+
+# PRをブラウザで開く
+gh pr view 123 --web
+
+# PRをマージ
+gh pr merge 123
+
+# PRを閉じる
+gh pr close 123
+
+# レビューを追加
+gh pr review 123 --approve
+gh pr review 123 --request-changes --body "Please fix..."
+gh pr review 123 --comment --body "Looks good!"</code></pre>
+
+          <h4>Issue操作</h4>
+          <pre><code># Issueを作成
+gh issue create --title "Bug report" --body "Description"
+
+# Issueの一覧
+gh issue list
+
+# Issueを表示
+gh issue view 456
+
+# Issueを閉じる
+gh issue close 456
+
+# Issueにコメント
+gh issue comment 456 --body "Working on this"</code></pre>
+
+          <h4>リポジトリ操作</h4>
+          <pre><code># リポジトリを作成
+gh repo create my-project --public
+gh repo create my-project --private
+
+# リポジトリをクローン
+gh repo clone user/repository
+
+# リポジトリをフォーク
+gh repo fork user/repository
+
+# リポジトリをブラウザで開く
+gh repo view --web</code></pre>
+        </div>
+
+        <h3>GitHub Actionsとの連携</h3>
+        <p>
+          GitHub Actionsをコマンドラインから操作できます。
+        </p>
+        <div class="command-block">
+          <pre><code># Workflowの一覧
+gh workflow list
+
+# Workflowを実行
+gh workflow run ci.yml
+
+# Workflowの実行結果を表示
+gh run list
+gh run view 123456
+
+# Workflowのログを表示
+gh run view 123456 --log</code></pre>
+        </div>
+
+        <h3>GitHub固有の.git設定</h3>
+        <p>
+          GitHubとの連携をスムーズにする設定です。
+        </p>
+        <div class="command-block">
+          <pre><code># GitHubのユーザー名を設定
+git config --global github.user "your-username"
+
+# SSH接続をデフォルトに
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+# PRブランチを取得できるようにする
+git config --add remote.origin.fetch '+refs/pull/*/head:refs/remotes/origin/pr/*'
+git fetch origin
+git checkout origin/pr/123
+
+# デフォルトブランチをmainに
+git config --global init.defaultBranch main</code></pre>
+        </div>
+
+        <h3>便利なGitHub機能</h3>
+        <div class="command-block">
+          <h4>GitHub上でファイルを直接編集</h4>
+          <pre><code># URLに.github.devを付けるor 「.」キーを押す
+https://github.com/user/repo
+↓
+https://github.dev/user/repo
+
+# VSCodeがweb上で起動し、直接編集可能</code></pre>
+
+          <h4>特定のコミットでファイルを参照</h4>
+          <pre><code># URLにcommit SHAを含める
+https://github.com/user/repo/blob/abc123/path/to/file.js
+
+# 行番号を指定
+https://github.com/user/repo/blob/main/file.js#L10-L20</code></pre>
+
+          <h4>READMEでバッジを表示</h4>
+          <pre><code># CIステータス
+![CI](https://github.com/user/repo/workflows/CI/badge.svg)
+
+# カバレッジ
+![Coverage](https://codecov.io/gh/user/repo/branch/main/graph/badge.svg)
+
+# ライセンス
+![License](https://img.shields.io/github/license/user/repo)</code></pre>
+        </div>
+
+        <h3>ベストプラクティス</h3>
+        <div class="command-block">
+          <pre><code># Pull Requestのベストプラクティス
+
+1. 小さくkeep（変更行数を少なく）
+2. 明確なタイトルと説明
+3. 関連Issueをリンク
+4. レビューアを指定
+5. CIが通ってからマージ依頼
+6. マージ後はブランチを削除
+7. Draft PRを活用して早めにフィードバック
+
+# Issueのベストプラクティス
+
+1. 再現手順を明記
+2. 環境情報を追加
+3. スクリーンショットを添付
+4. ラベルで分類
+5. テンプレートを活用
+
+# コラボレーション
+
+1. CODE_OF_CONDUCT.mdを追加
+2. CONTRIBUTING.mdで貢献方法を説明
+3. Issue/PRテンプレートを設定
+4. READMEを充実させる
+5. ライセンスを明記</code></pre>
+        </div>
       </section>
     </article>
 
@@ -104,9 +837,54 @@ import Navigation from '../../../components/git-cheatsheet/Navigation.astro';
     padding-top: 1rem;
   }
 
+  h3 {
+    font-size: 1.4rem;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    color: #444;
+    border-bottom: 2px solid #f0f0f0;
+    padding-bottom: 0.5rem;
+  }
+
+  h4 {
+    font-size: 1.1rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    color: #555;
+  }
+
   p {
     margin-bottom: 1rem;
     color: #444;
+  }
+
+  .command-block {
+    background: #f8f9fa;
+    border-left: 4px solid #667eea;
+    padding: 1.5rem;
+    margin: 1.5rem 0;
+    border-radius: 4px;
+  }
+
+  .command-block h4 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: #667eea;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 1rem 0;
+  }
+
+  code {
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.9rem;
+    line-height: 1.5;
   }
 
   .note {


### PR DESCRIPTION
## 概要

`tips.astro`のセクション17〜20に詳細なコンテンツを追加しました。

## 変更内容

### セクション17: .gitignoreの設定
- .gitignoreの基本文法とパターンルール
- 言語・フレームワーク別パターン（Node.js、Python、Java）
- 汎用的な除外パターン
- .gitignoreの管理方法（追加、既存ファイルの適用）
- 便利なリソース（gitignore.io、GitHubテンプレート）

### セクション18: Git Hooks
- Hooksの種類（クライアント側、サーバー側）
- Hooksの実装例（pre-commit、commit-msg、pre-push）
- Hooksの有効化とテスト
- Huskyでの管理（lint-stagedとの組み合わせ）

### セクション19: 実務で役立つTips
- コミットメッセージのベストプラクティス（Conventional Commits）
- ブランチ戦略（GitHub Flow、Git Flow、Trunk-Based Development）
- トラブルシューティング（間違ったファイル、大きなファイル、間違ったブランチ）
- パフォーマンス最適化（浅いクローン、部分クローン）
- セキュリティベストプラクティス

### セクション20: GitHub固有の操作
- GitHub CLI (gh)のインストールと使い方
- Pull Request操作（作成、レビュー、マージ）
- Issue操作
- リポジトリ操作（作成、フォーク）
- GitHub Actionsとの連携
- GitHub固有の.git設定
- 便利なGitHub機能（github.dev、行番号指定、バッジ）
- ベストプラクティス

## 保持した構造

- ✅ 既存のセクション番号（17〜20）を維持
- ✅ タイトル「設定・Tips編」を維持
- ✅ 既存のセクションIDを維持
- ✅ スタイルとレイアウトを統一

## 特徴

- 日本語で詳細な説明を記載
- 実践的なコマンド例を豊富に掲載
- 実務ですぐに使えるテンプレートや設定例
- ベストプラクティスと注意点を明記
- 他のセクションと同じスタイルで統一

## テスト

- [x] 既存のセクション番号を保持
- [x] 詳細なコンテンツを追加
- [x] ブランチへのプッシュ完了

## 完了

これでGitチートシートの全セクション（1〜20）のコンテンツが完成します！
