### PR TITLE
Add robots.txt and sitemap for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Helper scripts for Git workflow (run from repository root):
 | `./scripts/checkout-latest-branch.sh` | Fetch remote and checkout the most recently updated branch (excluding main/master) |
 | `./scripts/commit-and-push.sh "<message>"` | Stage all changes, commit with the given message, and push to origin |
 
+## SEO
+
+- **Sitemap**: Generated at build time by `@astrojs/sitemap` (output: `/sitemap-index.xml`).
+- **robots.txt**: `public/robots.txt` allows all crawlers and points to the sitemap.
+
 ## Deployment
 
 The site is automatically deployed to GitHub Pages when changes are pushed to the `main` branch.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,8 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://hrstsh.github.io',
   base: '/',
+  integrations: [sitemap()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hrstsh.github.io",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.2.1",
         "astro": "^4.16.0"
       },
       "devDependencies": {
@@ -126,6 +127,17 @@
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
       }
     },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.0.tgz",
+      "integrity": "sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.2",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.25.76"
+      }
+    },
     "node_modules/@astrojs/telemetry": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.1.0.tgz",
@@ -182,6 +194,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1855,6 +1868,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.2.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
+      "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2083,6 +2114,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5218,6 +5255,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5278,6 +5316,15 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/section-matter": {
@@ -5389,6 +5436,31 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.2.tgz",
+      "integrity": "sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5425,6 +5497,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5614,6 +5692,12 @@
       "dependencies": {
         "semver": "^7.3.8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.2.1",
     "astro": "^4.16.0"
   },
   "devDependencies": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://hrstsh.github.io/sitemap-index.xml


### PR DESCRIPTION
## 概要

検索エンジンのクローラーを許可し、サイトマップを自動生成するための基本的なSEO設定を追加しました。

## 変更内容

### 1. robots.txt の追加

**ファイル**: `public/robots.txt`

- すべてのクローラー（User-agent: *）を許可
- サイトマップの場所を指定
- GitHub Pagesのビルド時に自動的に配置される

```txt
User-agent: *
Allow: /

Sitemap: https://hrstsh.github.io/sitemap-index.xml
```

### 2. サイトマップの自動生成

**ファイル**: `astro.config.mjs`

- `@astrojs/sitemap` インテグレーションを追加
- ビルド時に全ページのサイトマップを自動生成
- `sitemap-index.xml` および個別のサイトマップファイルが生成される

### 3. 依存関係の追加

**ファイル**: `package.json`

- `@astrojs/sitemap@^3.2.1` を dependencies に追加

## マージ後の作業

1. **依存関係のインストール**
   ```bash
   npm install
   ```

2. **ビルドの実行**
   ```bash
   npm run build
   ```
   サイトマップが `dist/` ディレクトリに生成されます。

3. **デプロイ後の確認**
   - https://hrstsh.github.io/robots.txt にアクセスして確認
   - https://hrstsh.github.io/sitemap-index.xml にアクセスして確認

4. **Google Search Consoleへの登録**（任意）
   - [Google Search Console](https://search.google.com/search-console/) にアクセス
   - プロパティを追加: `https://hrstsh.github.io`
   - サイトマップを送信: `sitemap-index.xml`

## 期待される効果

- ✅ 検索エンジンのクローラーがサイトにアクセス可能になる
- ✅ 全ページが自動的にサイトマップに含まれる
- ✅ Google等の検索エンジンでのインデックス登録が容易になる
- ✅ 検索結果に表示されるようになる（数日〜2週間程度）

## テスト

- [x] robots.txt を作成
- [x] astro.config.mjs にサイトマップ設定を追加
- [x] package.json に依存関係を追加
- [ ] マージ後にビルドして動作確認
