### PR TITLE
Fix sitemap generation error

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,5 +4,10 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://hrstsh.github.io',
   base: '/',
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      filter: (page) => true,
+      customPages: [],
+    }),
+  ],
 });


### PR DESCRIPTION
## 問題

ビルド時に以下のエラーが発生していました：

```
Cannot read properties of undefined (reading 'reduce')
  Location:
    /home/runner/work/hrstsh.github.io/hrstsh.github.io/node_modules/@astrojs/sitemap/dist/index.js:69:37
```

## 原因

`@astrojs/sitemap` が `i18n` 設定を参照しようとするが、設定がないため `undefined` エラーが発生していました。

## 修正内容

**ファイル**: `astro.config.mjs`

明示的な sitemap 設定オプションを追加：

```javascript
integrations: [
  sitemap({
    filter: (page) => true,  // 全ページを含める
    customPages: [],          // カスタムページなし
  }),
],
```

## 期待される動作

- ✅ ビルドが正常に完了する
- ✅ サイトマップが正しく生成される
- ✅ 全ページが sitemap-index.xml に含まれる

## テスト

マージ後、GitHub Actions でビルドが成功することを確認してください。
