### PR TITLE
Add Google Search Console verification meta tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,6 +13,7 @@ const { title } = Astro.props;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google-site-verification" content="g_JyuwwxxKRZEqFVR8hB6-9Q_70v6CmlVbM1-GBtHbw" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>


### PR DESCRIPTION
## 概要

Google Search Console でドメイン所有権を確認するための検証用メタタグを追加しました。

## 変更内容

**ファイル**: `src/layouts/Layout.astro`

`<head>` セクションに以下のメタタグを追加：

```html
<meta name="google-site-verification" content="g_JyuwwxxKRZEqFVR8hB6-9Q_70v6CmlVbM1-GBtHbw" />
```

### 追加位置

- `<meta charset>` と `<meta name="viewport">` の直後
- `<link>` タグの前
- このレイアウトを使用する全ページに適用されます

## マージ後の作業

1. **デプロイを待つ**
   - GitHub Actions でビルドとデプロイが完了するまで待機

2. **メタタグの確認**
   - https://hrstsh.github.io にアクセス
   - ページのソースを表示して、メタタグが含まれていることを確認

3. **Google Search Console で確認**
   - Google Search Console に戻る
   - 「確認」ボタンをクリック
   - 所有権が確認されたメッセージが表示される

4. **サイトマップの送信**
   - 確認後、「サイトマップ」セクションに移動
   - `sitemap-index.xml` を入力して送信

## 期待される効果

- ✅ Google Search Console でドメイン所有権が確認できる
- ✅ サイトのインデックス状況を監視できる
- ✅ 検索パフォーマンスのデータを取得できる
- ✅ サイトマップを送信してクローリングを促進できる

## テスト

- [x] Layout.astro にメタタグを追加
- [ ] マージ後にデプロイを確認
- [ ] GSC で所有権確認を完了
