### PR TITLE
Fix sitemap generation (retry with proper configuration)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,13 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://hrstsh.github.io',
   base: '/',
+  integrations: [
+    sitemap({
+      filter: (page) => true,
+      customPages: [],
+    }),
+  ],
 });


### PR DESCRIPTION
## 概要

サイトマップ生成のエラーを修正し、再度設定を適用します。

## 問題

PR #20 でサイトマップ設定を追加しましたが、ビルド時にエラーが発生：

```
Cannot read properties of undefined (reading 'reduce')
```

## 修正内容

**ファイル**: `astro.config.mjs`

明示的な sitemap 設定オプションを追加してエラーを回避：

```javascript
import { defineConfig } from 'astro/config';
import sitemap from '@astrojs/sitemap';

export default defineConfig({
  site: 'https://hrstsh.github.io',
  base: '/',
  integrations: [
    sitemap({
      filter: (page) => true,  // 全ページを含める
      customPages: [],          // カスタムページなし
    }),
  ],
});
```

## サイトマップの生成場所

ビルド後、サイトマップは以下の場所に生成されます：

- **ローカル**: `dist/sitemap-index.xml`
- **公開後**: `https://hrstsh.github.io/sitemap-index.xml`

複数ページがある場合、個別のサイトマップファイル（`sitemap-0.xml`、`sitemap-1.xml`など）も生成され、`sitemap-index.xml` がそれらをまとめます。

## マージ後の確認

1. **GitHub Actions でビルドが成功することを確認**

2. **デプロイ後、以下のURLにアクセスして確認**:
   - https://hrstsh.github.io/sitemap-index.xml
   - https://hrstsh.github.io/sitemap-0.xml

3. **Google Search Console でサイトマップを送信**:
   - `sitemap-index.xml` を入力して送信

## 期待される効果

- ✅ ビルドが正常に完了する
- ✅ サイトマップが正しく生成される
- ✅ 全ページがサイトマップに含まれる
- ✅ Google Search Console でサイトマップを送信できる

## 注意

`package.json` には既に `@astrojs/sitemap` が追加されているため、再度インストールする必要はありません。
