### PR TITLE
Add Docker Command Cheatsheet

### DIFF
--- a/src/components/docker-cheatsheet/Navigation.astro
+++ b/src/components/docker-cheatsheet/Navigation.astro
@@ -1,0 +1,73 @@
+---
+const { currentPage } = Astro.props;
+
+const pages = [
+  { path: '/tools/docker-cheatsheet', label: '目次' },
+  { path: '/tools/docker-cheatsheet/basics', label: '基本操作' },
+  { path: '/tools/docker-cheatsheet/images', label: 'イメージ管理' },
+  { path: '/tools/docker-cheatsheet/containers', label: 'コンテナ操作' },
+  { path: '/tools/docker-cheatsheet/compose', label: 'Docker Compose' },
+  { path: '/tools/docker-cheatsheet/tips', label: 'Tips' },
+];
+---
+
+<nav class="page-navigation">
+  <div class="nav-container">
+    {pages.map((page) => (
+      <a 
+        href={page.path} 
+        class:list={['nav-link', { active: currentPage === page.path }]}
+      >
+        {page.label}
+      </a>
+    ))}
+  </div>
+</nav>
+
+<style>
+  .page-navigation {
+    background: #f8f9fa;
+    border-bottom: 2px solid #667eea;
+    margin-bottom: 2rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .nav-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0.5rem 1rem;
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    flex-wrap: wrap;
+  }
+
+  .nav-link {
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    color: #666;
+    border-radius: 4px;
+    transition: all 0.2s;
+    white-space: nowrap;
+    font-size: 0.9rem;
+  }
+
+  .nav-link:hover {
+    background: #667eea;
+    color: white;
+  }
+
+  .nav-link.active {
+    background: #667eea;
+    color: white;
+    font-weight: 600;
+  }
+
+  @media (max-width: 768px) {
+    .nav-container {
+      flex-wrap: nowrap;
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,6 +37,10 @@ import Layout from '../layouts/Layout.astro';
           <h3>SQL基本コマンド集</h3>
           <p>データベース操作の実用的なリファレンス</p>
         </a>
+        <a href="/tools/docker-cheatsheet" class="tool-card">
+          <h3>Dockerコマンドチートシート</h3>
+          <p>コンテナ技術の必須コマンドを網羅</p>
+        </a>
       </div>
     </section>
   </main>

--- a/src/pages/tools/docker-cheatsheet/basics.astro
+++ b/src/pages/tools/docker-cheatsheet/basics.astro
@@ -1,0 +1,270 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Navigation from '../../../components/docker-cheatsheet/Navigation.astro';
+---
+
+<Layout title="基本操作 - Dockerコマンドチートシート">
+  <Navigation currentPage="/tools/docker-cheatsheet/basics" />
+  <main>
+    <h1>基本操作</h1>
+
+    <section>
+      <h2>Dockerとは</h2>
+      <p>
+        Dockerは、アプリケーションをコンテナという軽量な実行環境で動かすためのプラットフォームです。
+        コンテナを使うことで、開発環境と本番環境の差異をなくし、「自分の環境では動く」問題を解決します。
+      </p>
+    </section>
+
+    <section>
+      <h2>基本概念</h2>
+      <ul>
+        <li><strong>イメージ</strong>: アプリケーションとその依存関係をパッケージ化したテンプレート</li>
+        <li><strong>コンテナ</strong>: イメージから起動された実行環境の実体</li>
+        <li><strong>レジストリ</strong>: イメージを保存・共有する場所（Docker Hubなど）</li>
+        <li><strong>Dockerfile</strong>: イメージを作成するための設計図</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>インストール確認</h2>
+      <p>Dockerが正しくインストールされているか確認します。</p>
+      <pre><code class="language-bash"># バージョン確認
+docker --version
+# または
+docker version
+
+# Docker詳細情報の表示
+docker info</code></pre>
+    </section>
+
+    <section>
+      <h2>ヘルプの表示</h2>
+      <pre><code class="language-bash"># 全コマンドのヘルプ
+docker --help
+
+# 特定コマンドのヘルプ
+docker run --help
+docker build --help</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナの起動</h2>
+      <p><code>docker run</code>は最も基本的なコマンドです。イメージからコンテナを作成して起動します。</p>
+      <pre><code class="language-bash"># 基本形
+docker run [オプション] イメージ名 [コマンド]
+
+# Nginxコンテナを起動
+docker run nginx
+
+# コンテナ名を指定して起動
+docker run --name my-nginx nginx
+
+# バックグラウンドで起動（デタッチモード）
+docker run -d nginx
+
+# ポートマッピング（ホスト:コンテナ）
+docker run -d -p 8080:80 nginx</code></pre>
+      <p>✓ デタッチモード（<code>-d</code>）を使うと、コンテナがバックグラウンドで動作します</p>
+      <p>✗ デタッチモードなしで起動すると、ターミナルが占有されます</p>
+    </section>
+
+    <section>
+      <h2>コンテナの一覧表示</h2>
+      <pre><code class="language-bash"># 実行中のコンテナを表示
+docker ps
+
+# 全てのコンテナを表示（停止中も含む）
+docker ps -a
+
+# 最新のコンテナのみ表示
+docker ps -l
+
+# コンテナIDのみ表示
+docker ps -q</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナの停止・開始・再起動</h2>
+      <pre><code class="language-bash"># コンテナの停止（猶予時間あり）
+docker stop コンテナID
+docker stop my-nginx
+
+# コンテナの強制停止
+docker kill コンテナID
+
+# 停止中のコンテナを開始
+docker start コンテナID
+
+# コンテナを再起動
+docker restart コンテナID
+
+# 複数コンテナを一度に停止
+docker stop コンテナID1 コンテナID2</code></pre>
+      <p>✓ <code>stop</code>はグレースフルシャットダウン（正常終了）を試みます</p>
+      <p>✗ <code>kill</code>は即座に強制終了するため、データ損失の可能性があります</p>
+    </section>
+
+    <section>
+      <h2>コンテナの削除</h2>
+      <pre><code class="language-bash"># 停止中のコンテナを削除
+docker rm コンテナID
+
+# 実行中のコンテナを強制削除
+docker rm -f コンテナID
+
+# 複数コンテナを削除
+docker rm コンテナID1 コンテナID2
+
+# 停止中の全コンテナを削除
+docker container prune
+
+# 確認なしで削除
+docker container prune -f</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージの削除</h2>
+      <pre><code class="language-bash"># イメージを削除
+docker rmi イメージ名
+docker rmi nginx
+
+# イメージIDで削除
+docker rmi イメージID
+
+# 強制削除
+docker rmi -f イメージID
+
+# 未使用イメージを全て削除
+docker image prune
+
+# タグなしイメージも含めて削除
+docker image prune -a</code></pre>
+    </section>
+
+    <section>
+      <h2>よく使う組み合わせ</h2>
+      <pre><code class="language-bash"># コンテナ起動後、終了時に自動削除
+docker run --rm nginx
+
+# インタラクティブモードで起動（シェル操作）
+docker run -it ubuntu bash
+
+# デタッチモード + ポートマッピング + コンテナ名指定
+docker run -d -p 8080:80 --name my-web nginx
+
+# 環境変数を設定して起動
+docker run -e MY_VAR=value nginx</code></pre>
+    </section>
+
+    <section>
+      <h2>実用例</h2>
+      <pre><code class="language-bash"># Nginx Webサーバーを起動
+docker run -d -p 80:80 --name web-server nginx
+
+# MySQL データベースを起動
+docker run -d \
+  --name mysql-db \
+  -e MYSQL_ROOT_PASSWORD=mypassword \
+  -p 3306:3306 \
+  mysql:8.0
+
+# Node.js 開発環境を起動
+docker run -it --rm \
+  -v $(pwd):/app \
+  -w /app \
+  node:18 \
+  npm install</code></pre>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/tools/docker-cheatsheet">目次に戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: #333;
+    border-bottom: 2px solid #667eea;
+    padding-bottom: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  ul {
+    margin-bottom: 1rem;
+    padding-left: 2rem;
+  }
+
+  li {
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    line-height: 1.5;
+  }
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.9rem;
+  }
+
+  p code {
+    background: #f4f4f4;
+    color: #d63384;
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+
+  .page-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #667eea;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 1.1rem;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/pages/tools/docker-cheatsheet/compose.astro
+++ b/src/pages/tools/docker-cheatsheet/compose.astro
@@ -1,0 +1,346 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Navigation from '../../../components/docker-cheatsheet/Navigation.astro';
+---
+
+<Layout title="Docker Compose - Dockerコマンドチートシート">
+  <Navigation currentPage="/tools/docker-cheatsheet/compose" />
+  <main>
+    <h1>Docker Compose</h1>
+
+    <section>
+      <h2>Docker Composeとは</h2>
+      <p>
+        Docker Composeは、複数のコンテナを定義・実行するためのツールです。
+        YAMLファイルでサービスを定義し、一つのコマンドで全てのサービスを起動・停止できます。
+      </p>
+      <p>Webアプリケーションとデータベースなど、複数のコンテナを連携させる場合に便利です。</p>
+    </section>
+
+    <section>
+      <h2>docker-compose.ymlの基本構造</h2>
+      <pre><code class="language-yaml">version: '3.8'
+
+services:
+  # サービス1
+  web:
+    image: nginx:latest
+    ports:
+      - "8080:80"
+    volumes:
+      - ./html:/usr/share/nginx/html
+    depends_on:
+      - db
+
+  # サービス2
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: myapp
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:</code></pre>
+    </section>
+
+    <section>
+      <h2>サービスの起動・停止</h2>
+      <pre><code class="language-bash"># サービスを起動（フォアグラウンド）
+docker compose up
+
+# サービスをバックグラウンドで起動
+docker compose up -d
+
+# 特定のサービスのみ起動
+docker compose up web
+
+# ビルドしてから起動
+docker compose up --build
+
+# サービスを停止（コンテナは削除されない）
+docker compose stop
+
+# サービスを停止してコンテナを削除
+docker compose down
+
+# サービス停止 + ボリュームも削除
+docker compose down -v</code></pre>
+      <p>✓ <code>up -d</code>でバックグラウンド起動が推奨です</p>
+      <p>✗ <code>down -v</code>はデータベースのデータも削除されるので注意</p>
+    </section>
+
+    <section>
+      <h2>サービスの状態確認</h2>
+      <pre><code class="language-bash"># 実行中のサービス一覧
+docker compose ps
+
+# 全てのサービス（停止中も含む）
+docker compose ps -a
+
+# サービスのログを表示
+docker compose logs
+
+# 特定サービスのログ
+docker compose logs web
+
+# リアルタイムでログを表示
+docker compose logs -f
+
+# 最新100行のログ
+docker compose logs --tail=100</code></pre>
+    </section>
+
+    <section>
+      <h2>サービス内でコマンド実行</h2>
+      <pre><code class="language-bash"># 実行中のサービスでコマンド実行
+docker compose exec web bash
+docker compose exec db mysql -u root -p
+
+# 新しいコンテナでコマンドを実行
+docker compose run web npm install
+
+# 一度だけ実行して終了時に削除
+docker compose run --rm web node script.js</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージのビルド</h2>
+      <pre><code class="language-bash"># Dockerfileからイメージをビルド
+docker compose build
+
+# 特定サービスのみビルド
+docker compose build web
+
+# キャッシュを使わずにビルド
+docker compose build --no-cache
+
+# ビルドしてから起動
+docker compose up --build</code></pre>
+    </section>
+
+    <section>
+      <h2>サービスの再起動・更新</h2>
+      <pre><code class="language-bash"># サービスを再起動
+docker compose restart
+
+# 特定サービスのみ再起動
+docker compose restart web
+
+# 設定を再読み込みして再起動
+docker compose up -d --force-recreate
+
+# 変更されたサービスのみ再作成
+docker compose up -d</code></pre>
+    </section>
+
+    <section>
+      <h2>スケーリング</h2>
+      <pre><code class="language-bash"># サービスのインスタンス数を指定
+docker compose up -d --scale web=3
+
+# 複数サービスをスケール
+docker compose up -d --scale web=3 --scale worker=2</code></pre>
+      <p>※ ポートマッピングを使用する場合は、ポート番号の競合に注意が必要です。</p>
+    </section>
+
+    <section>
+      <h2>その他の便利なコマンド</h2>
+      <pre><code class="language-bash"># 別のComposeファイルを指定
+docker compose -f docker-compose.prod.yml up -d
+
+# プロジェクト名を指定
+docker compose -p myproject up -d
+
+# サービスの設定を表示
+docker compose config
+
+# サービスで実行中のプロセスを表示
+docker compose top
+
+# サービスを一時停止/再開
+docker compose pause
+docker compose unpause</code></pre>
+    </section>
+
+    <section>
+      <h2>実用例: Web + DB構成</h2>
+      <pre><code class="language-yaml">version: '3.8'
+
+services:
+  web:
+    build: ./web
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+      - DB_HOST=db
+      - DB_USER=root
+      - DB_PASSWORD=secret
+    volumes:
+      - ./web:/app
+      - /app/node_modules
+    depends_on:
+      - db
+    command: npm run dev
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres-data:</code></pre>
+      <p>起動方法：</p>
+      <pre><code class="language-bash"># 初回起動（ビルド含む）
+docker compose up -d --build
+
+# ログ確認
+docker compose logs -f web
+
+# データベースに接続
+docker compose exec db psql -U root -d myapp
+
+# 停止と削除
+docker compose down</code></pre>
+    </section>
+
+    <section>
+      <h2>開発時のワークフロー</h2>
+      <pre><code class="language-bash"># 1. サービスを起動
+docker compose up -d
+
+# 2. ログを監視
+docker compose logs -f
+
+# 3. コードを編集（ボリュームマウントで自動反映）
+
+# 4. 必要に応じてサービスを再起動
+docker compose restart web
+
+# 5. コンテナ内でコマンド実行
+docker compose exec web npm install new-package
+
+# 6. 作業終了時に停止
+docker compose down</code></pre>
+    </section>
+
+    <section>
+      <h2>トラブルシューティング</h2>
+      <pre><code class="language-bash"># 全てを削除して再構築
+docker compose down -v
+docker compose up -d --build
+
+# 特定サービスのみ再ビルド
+docker compose build --no-cache web
+docker compose up -d web
+
+# ネットワークの問題を解決
+docker compose down
+docker network prune
+docker compose up -d</code></pre>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/tools/docker-cheatsheet">目次に戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: #333;
+    border-bottom: 2px solid #667eea;
+    padding-bottom: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  ul {
+    margin-bottom: 1rem;
+    padding-left: 2rem;
+  }
+
+  li {
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    line-height: 1.5;
+  }
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.9rem;
+  }
+
+  p code {
+    background: #f4f4f4;
+    color: #d63384;
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+
+  .page-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #667eea;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 1.1rem;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/pages/tools/docker-cheatsheet/containers.astro
+++ b/src/pages/tools/docker-cheatsheet/containers.astro
@@ -60,47 +60,47 @@ docker run --restart=on-failure:3 nginx  # 最大3回まで</code></pre>
       <h2>実行中コンテナでコマンド実行</h2>
       <p><code>docker exec</code>を使うと、実行中のコンテナ内でコマンドを実行できます。</p>
       <pre><code class="language-bash"># コンテナ内でbashを起動
-docker exec -it コンテナID bash
+docker exec -it コンテナ名 bash
 docker exec -it my-nginx bash
 
 # Alpine Linuxの場合（shを使用）
-docker exec -it コンテナID sh
+docker exec -it コンテナ名 sh
 
 # コマンドを直接実行
-docker exec コンテナID ls -la /app
+docker exec コンテナ名 ls -la /app
 docker exec my-nginx nginx -v
 
 # rootユーザーで実行
-docker exec -u root -it コンテナID bash
+docker exec -u root -it コンテナ名 bash
 
 # 環境変数を設定して実行
-docker exec -e MY_VAR=value コンテナID printenv
+docker exec -e MY_VAR=value コンテナ名 printenv
 
 # 作業ディレクトリを指定して実行
-docker exec -w /app コンテナID npm install</code></pre>
+docker exec -w /app コンテナ名 npm install</code></pre>
     </section>
 
     <section>
       <h2>コンテナのログ確認</h2>
       <pre><code class="language-bash"># コンテナのログを表示
-docker logs コンテナID
+docker logs コンテナ名
 docker logs my-nginx
 
 # リアルタイムでログを追跡（tail -f相当）
-docker logs -f コンテナID
+docker logs -f コンテナ名
 
 # 最後の100行だけ表示
-docker logs --tail 100 コンテナID
+docker logs --tail 100 コンテナ名
 
 # タイムスタンプ付きで表示
-docker logs -t コンテナID
+docker logs -t コンテナ名
 
 # 特定時刻以降のログを表示
-docker logs --since 2024-01-01T00:00:00 コンテナID
-docker logs --since 10m コンテナID  # 10分前から
+docker logs --since 2024-01-01T00:00:00 コンテナ名
+docker logs --since 10m コンテナ名  # 10分前から
 
 # 特定時刻までのログを表示
-docker logs --until 2024-01-31T23:59:59 コンテナID</code></pre>
+docker logs --until 2024-01-31T23:59:59 コンテナ名</code></pre>
     </section>
 
     <section>
@@ -109,45 +109,45 @@ docker logs --until 2024-01-31T23:59:59 コンテナID</code></pre>
 docker stats
 
 # 特定コンテナのみ表示
-docker stats コンテナID
+docker stats コンテナ名
 
 # 一度だけ表示（更新なし）
 docker stats --no-stream
 
 # コンテナ内のプロセス一覧
-docker top コンテナID
+docker top コンテナ名
 
 # コンテナの詳細情報を確認
-docker inspect コンテナID
+docker inspect コンテナ名
 
 # 特定の情報を取得
-docker inspect --format='{{.State.Status}}' コンテナID
-docker inspect --format='{{.NetworkSettings.IPAddress}}' コンテナID
+docker inspect --format='&#123;&#123;.State.Status&#125;&#125;' コンテナ名
+docker inspect --format='&#123;&#123;.NetworkSettings.IPAddress&#125;&#125;' コンテナ名
 
 # ポートマッピングの確認
-docker port コンテナID</code></pre>
+docker port コンテナ名</code></pre>
     </section>
 
     <section>
       <h2>ファイルのコピー</h2>
       <p>ホストとコンテナ間でファイルをコピーできます。</p>
       <pre><code class="language-bash"># ホストからコンテナへ
-docker cp /host/file.txt コンテナID:/container/path/
+docker cp /host/file.txt コンテナ名:/container/path/
 docker cp ./config.json my-nginx:/etc/nginx/
 
 # コンテナからホストへ
-docker cp コンテナID:/container/file.txt /host/path/
+docker cp コンテナ名:/container/file.txt /host/path/
 docker cp my-nginx:/var/log/nginx/access.log ./logs/
 
 # ディレクトリごとコピー
-docker cp /host/directory コンテナID:/container/path/
-docker cp コンテナID:/app/logs ./backup/</code></pre>
+docker cp /host/directory コンテナ名:/container/path/
+docker cp コンテナ名:/app/logs ./backup/</code></pre>
     </section>
 
     <section>
       <h2>コンテナへのアタッチ</h2>
       <pre><code class="language-bash"># 実行中コンテナにアタッチ（出力を見る）
-docker attach コンテナID
+docker attach コンテナ名
 
 # アタッチを解除（コンテナを止めずに）
 # Ctrl+P, Ctrl+Q を順に押す</code></pre>
@@ -157,20 +157,20 @@ docker attach コンテナID
     <section>
       <h2>コンテナの一時停止と再開</h2>
       <pre><code class="language-bash"># コンテナを一時停止（プロセスを凍結）
-docker pause コンテナID
+docker pause コンテナ名
 
 # 停止したコンテナを再開
-docker unpause コンテナID</code></pre>
+docker unpause コンテナ名</code></pre>
     </section>
 
     <section>
       <h2>コンテナの削除</h2>
       <pre><code class="language-bash"># 停止中コンテナを削除
-docker rm コンテナID
+docker rm コンテナ名
 docker rm my-nginx
 
 # 実行中コンテナを強制削除
-docker rm -f コンテナID
+docker rm -f コンテナ名
 
 # 複数コンテナを削除
 docker rm コンテナ1 コンテナ2 コンテナ3
@@ -189,13 +189,13 @@ docker rm $(docker ps -aq)</code></pre>
     <section>
       <h2>コンテナからイメージを作成</h2>
       <pre><code class="language-bash"># 実行中コンテナからイメージを作成
-docker commit コンテナID my-custom-image:1.0
+docker commit コンテナ名 my-custom-image:1.0
 
 # メッセージと作者情報を付けて作成
-docker commit -m "Added custom config" -a "Your Name" コンテナID my-image:1.0
+docker commit -m "Added custom config" -a "Your Name" コンテナ名 my-image:1.0
 
 # コンテナを停止せずに作成
-docker commit --pause=false コンテナID my-image:1.0</code></pre>
+docker commit --pause=false コンテナ名 my-image:1.0</code></pre>
       <p>※ 本番環境ではDockerfileを使用することを推奨します</p>
     </section>
 

--- a/src/pages/tools/docker-cheatsheet/containers.astro
+++ b/src/pages/tools/docker-cheatsheet/containers.astro
@@ -1,0 +1,326 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Navigation from '../../../components/docker-cheatsheet/Navigation.astro';
+---
+
+<Layout title="コンテナ操作 - Dockerコマンドチートシート">
+  <Navigation currentPage="/tools/docker-cheatsheet/containers" />
+  <main>
+    <h1>コンテナ操作</h1>
+
+    <section>
+      <h2>コンテナ起動の主要オプション</h2>
+      <pre><code class="language-bash"># デタッチモード（バックグラウンド実行）
+docker run -d nginx
+
+# コンテナ名を指定
+docker run --name my-nginx nginx
+
+# ポートマッピング（ホスト:コンテナ）
+docker run -p 8080:80 nginx
+docker run -p 127.0.0.1:8080:80 nginx  # IP指定
+
+# 複数ポートのマッピング
+docker run -p 8080:80 -p 8443:443 nginx
+
+# ボリュームマウント（データ永続化）
+docker run -v /host/path:/container/path nginx
+docker run -v $(pwd):/app node:18
+
+# 読み取り専用でマウント
+docker run -v /host/path:/container/path:ro nginx
+
+# 名前付きボリュームを使用
+docker run -v my-volume:/data nginx
+
+# 環境変数の設定
+docker run -e NODE_ENV=production node:18
+docker run -e DB_HOST=localhost -e DB_PORT=5432 my-app
+
+# 環境変数をファイルから読み込む
+docker run --env-file .env my-app
+
+# コンテナ終了時に自動削除
+docker run --rm nginx
+
+# インタラクティブモード（シェル操作）
+docker run -it ubuntu bash
+docker run -it --rm alpine sh
+
+# リソース制限
+docker run --memory="512m" --cpus="1.5" nginx
+
+# 再起動ポリシーの設定
+docker run --restart=always nginx
+docker run --restart=unless-stopped nginx
+docker run --restart=on-failure:3 nginx  # 最大3回まで</code></pre>
+    </section>
+
+    <section>
+      <h2>実行中コンテナでコマンド実行</h2>
+      <p><code>docker exec</code>を使うと、実行中のコンテナ内でコマンドを実行できます。</p>
+      <pre><code class="language-bash"># コンテナ内でbashを起動
+docker exec -it コンテナID bash
+docker exec -it my-nginx bash
+
+# Alpine Linuxの場合（shを使用）
+docker exec -it コンテナID sh
+
+# コマンドを直接実行
+docker exec コンテナID ls -la /app
+docker exec my-nginx nginx -v
+
+# rootユーザーで実行
+docker exec -u root -it コンテナID bash
+
+# 環境変数を設定して実行
+docker exec -e MY_VAR=value コンテナID printenv
+
+# 作業ディレクトリを指定して実行
+docker exec -w /app コンテナID npm install</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナのログ確認</h2>
+      <pre><code class="language-bash"># コンテナのログを表示
+docker logs コンテナID
+docker logs my-nginx
+
+# リアルタイムでログを追跡（tail -f相当）
+docker logs -f コンテナID
+
+# 最後の100行だけ表示
+docker logs --tail 100 コンテナID
+
+# タイムスタンプ付きで表示
+docker logs -t コンテナID
+
+# 特定時刻以降のログを表示
+docker logs --since 2024-01-01T00:00:00 コンテナID
+docker logs --since 10m コンテナID  # 10分前から
+
+# 特定時刻までのログを表示
+docker logs --until 2024-01-31T23:59:59 コンテナID</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナのステータス確認</h2>
+      <pre><code class="language-bash"># コンテナのリソース使用状況を確認
+docker stats
+
+# 特定コンテナのみ表示
+docker stats コンテナID
+
+# 一度だけ表示（更新なし）
+docker stats --no-stream
+
+# コンテナ内のプロセス一覧
+docker top コンテナID
+
+# コンテナの詳細情報を確認
+docker inspect コンテナID
+
+# 特定の情報を取得
+docker inspect --format='{{.State.Status}}' コンテナID
+docker inspect --format='{{.NetworkSettings.IPAddress}}' コンテナID
+
+# ポートマッピングの確認
+docker port コンテナID</code></pre>
+    </section>
+
+    <section>
+      <h2>ファイルのコピー</h2>
+      <p>ホストとコンテナ間でファイルをコピーできます。</p>
+      <pre><code class="language-bash"># ホストからコンテナへ
+docker cp /host/file.txt コンテナID:/container/path/
+docker cp ./config.json my-nginx:/etc/nginx/
+
+# コンテナからホストへ
+docker cp コンテナID:/container/file.txt /host/path/
+docker cp my-nginx:/var/log/nginx/access.log ./logs/
+
+# ディレクトリごとコピー
+docker cp /host/directory コンテナID:/container/path/
+docker cp コンテナID:/app/logs ./backup/</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナへのアタッチ</h2>
+      <pre><code class="language-bash"># 実行中コンテナにアタッチ（出力を見る）
+docker attach コンテナID
+
+# アタッチを解除（コンテナを止めずに）
+# Ctrl+P, Ctrl+Q を順に押す</code></pre>
+      <p>※ <code>attach</code>と<code>exec</code>の違い: attachはメインプロセスに接続、execは新しいプロセスを起動</p>
+    </section>
+
+    <section>
+      <h2>コンテナの一時停止と再開</h2>
+      <pre><code class="language-bash"># コンテナを一時停止（プロセスを凍結）
+docker pause コンテナID
+
+# 停止したコンテナを再開
+docker unpause コンテナID</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナの削除</h2>
+      <pre><code class="language-bash"># 停止中コンテナを削除
+docker rm コンテナID
+docker rm my-nginx
+
+# 実行中コンテナを強制削除
+docker rm -f コンテナID
+
+# 複数コンテナを削除
+docker rm コンテナ1 コンテナ2 コンテナ3
+
+# 停止中の全コンテナを削除
+docker container prune
+
+# 確認なしで削除
+docker container prune -f
+
+# 全コンテナを停止して削除
+docker stop $(docker ps -aq)
+docker rm $(docker ps -aq)</code></pre>
+    </section>
+
+    <section>
+      <h2>コンテナからイメージを作成</h2>
+      <pre><code class="language-bash"># 実行中コンテナからイメージを作成
+docker commit コンテナID my-custom-image:1.0
+
+# メッセージと作者情報を付けて作成
+docker commit -m "Added custom config" -a "Your Name" コンテナID my-image:1.0
+
+# コンテナを停止せずに作成
+docker commit --pause=false コンテナID my-image:1.0</code></pre>
+      <p>※ 本番環境ではDockerfileを使用することを推奨します</p>
+    </section>
+
+    <section>
+      <h2>実用例集</h2>
+      <pre><code class="language-bash"># WordPress + MySQL を起動
+# MySQL
+docker run -d \
+  --name wordpress-db \
+  -e MYSQL_ROOT_PASSWORD=root \
+  -e MYSQL_DATABASE=wordpress \
+  mysql:8.0
+
+# WordPress
+docker run -d \
+  --name wordpress \
+  -p 8080:80 \
+  -e WORDPRESS_DB_HOST=wordpress-db:3306 \
+  -e WORDPRESS_DB_PASSWORD=root \
+  --link wordpress-db \
+  wordpress
+
+# Redisをキャッシュサーバーとして起動
+docker run -d \
+  --name redis-cache \
+  -p 6379:6379 \
+  redis:alpine
+
+# PostgreSQLをデータボリュームで起動
+docker run -d \
+  --name postgres-db \
+  -e POSTGRES_PASSWORD=mypassword \
+  -e POSTGRES_DB=mydb \
+  -v postgres-data:/var/lib/postgresql/data \
+  -p 5432:5432 \
+  postgres:15
+
+# MongoDBを起動
+docker run -d \
+  --name mongodb \
+  -e MONGO_INITDB_ROOT_USERNAME=admin \
+  -e MONGO_INITDB_ROOT_PASSWORD=password \
+  -v mongo-data:/data/db \
+  -p 27017:27017 \
+  mongo:7</code></pre>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/tools/docker-cheatsheet">目次に戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: #333;
+    border-bottom: 2px solid #667eea;
+    padding-bottom: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    line-height: 1.5;
+  }
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.9rem;
+  }
+
+  p code {
+    background: #f4f4f4;
+    color: #d63384;
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+
+  .page-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #667eea;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 1.1rem;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/pages/tools/docker-cheatsheet/images.astro
+++ b/src/pages/tools/docker-cheatsheet/images.astro
@@ -1,0 +1,295 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Navigation from '../../../components/docker-cheatsheet/Navigation.astro';
+---
+
+<Layout title="イメージ管理 - Dockerコマンドチートシート">
+  <Navigation currentPage="/tools/docker-cheatsheet/images" />
+  <main>
+    <h1>イメージ管理</h1>
+
+    <section>
+      <h2>イメージの検索</h2>
+      <p>Docker Hubでイメージを検索します。</p>
+      <pre><code class="language-bash"># Docker Hubでイメージを検索
+docker search nginx
+docker search mysql
+
+# 公式イメージのみ表示
+docker search --filter "is-official=true" nginx
+
+# 星数が一定以上のものを検索
+docker search --filter "stars=100" nginx</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージの取得（Pull）</h2>
+      <p>レジストリからイメージをダウンロードします。</p>
+      <pre><code class="language-bash"># 最新版を取得（latestタグ）
+docker pull nginx
+docker pull ubuntu
+
+# 特定バージョンを取得
+docker pull nginx:1.25
+docker pull mysql:8.0
+docker pull node:18-alpine
+
+# 特定のレジストリから取得
+docker pull ghcr.io/user/repo:tag</code></pre>
+      <p>✓ 本番環境では必ずタグを明示的に指定しましょう</p>
+      <p>✗ <code>latest</code>タグは不安定な場合があるため注意が必要です</p>
+    </section>
+
+    <section>
+      <h2>イメージの一覧表示</h2>
+      <pre><code class="language-bash"># ローカルのイメージ一覧
+docker images
+docker image ls
+
+# イメージIDのみ表示
+docker images -q
+
+# 中間イメージも含めて表示
+docker images -a
+
+# タグなしイメージのみ表示
+docker images -f "dangling=true"</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージ詳細情報の確認</h2>
+      <pre><code class="language-bash"># イメージの詳細情報をJSON形式で表示
+docker inspect nginx
+docker inspect イメージID
+
+# 特定の情報だけを取得
+docker inspect --format='{{.Config.Env}}' nginx
+docker inspect --format='{{.Architecture}}' nginx
+
+# イメージの履歴を確認
+docker history nginx
+docker history --no-trunc nginx</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージの削除</h2>
+      <pre><code class="language-bash"># イメージを名前で削除
+docker rmi nginx
+docker image rm nginx:1.25
+
+# イメージIDで削除
+docker rmi イメージID
+
+# 複数イメージを一度に削除
+docker rmi nginx mysql redis
+
+# 強制削除（コンテナが使用中でも）
+docker rmi -f nginx
+
+# 未使用イメージを全て削除
+docker image prune
+
+# タグなしイメージも含めて削除
+docker image prune -a
+
+# 確認なしで実行
+docker image prune -f</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージのビルド</h2>
+      <p>Dockerfileからイメージを作成します。</p>
+      <pre><code class="language-bash"># カレントディレクトリのDockerfileからビルド
+docker build .
+
+# タグを付けてビルド
+docker build -t my-app:1.0 .
+docker build -t myname/my-app:latest .
+
+# Dockerfileを指定してビルド
+docker build -f Dockerfile.prod -t my-app:prod .
+
+# キャッシュを使わずにビルド
+docker build --no-cache -t my-app .
+
+# ビルド引数を渡す
+docker build --build-arg NODE_VERSION=18 -t my-app .
+
+# ビルドコンテキストを指定
+docker build -t my-app ./src</code></pre>
+    </section>
+
+    <section>
+      <h2>Dockerfileの基本</h2>
+      <pre><code class="language-dockerfile"># ベースイメージの指定
+FROM node:18-alpine
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# ファイルのコピー
+COPY package*.json ./
+
+# コマンドの実行
+RUN npm install
+
+# アプリコードをコピー
+COPY . .
+
+# ポートの公開
+EXPOSE 3000
+
+# コンテナ起動時のコマンド
+CMD ["npm", "start"]</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージのタグ付け</h2>
+      <pre><code class="language-bash"># 既存イメージに新しいタグを付ける
+docker tag my-app:1.0 my-app:latest
+docker tag my-app myname/my-app:1.0
+
+# レジストリ用のタグ付け
+docker tag my-app:1.0 registry.example.com/my-app:1.0
+docker tag my-app ghcr.io/username/my-app:latest</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージのプッシュ（Push）</h2>
+      <pre><code class="language-bash"># Docker Hubにプッシュ
+docker push myname/my-app:1.0
+docker push myname/my-app:latest
+
+# プライベートレジストリにプッシュ
+docker push registry.example.com/my-app:1.0
+
+# GitHub Container Registryにプッシュ
+docker push ghcr.io/username/my-app:latest</code></pre>
+      <p>※ プッシュ前に<code>docker login</code>で認証が必要です</p>
+    </section>
+
+    <section>
+      <h2>イメージの保存と読込</h2>
+      <p>イメージをファイルとして保存したり、読み込んだりできます。</p>
+      <pre><code class="language-bash"># イメージをtarファイルに保存
+docker save -o nginx.tar nginx
+docker save nginx > nginx.tar
+
+# 複数イメージを一つのファイルに保存
+docker save -o images.tar nginx mysql redis
+
+# tarファイルからイメージを読み込む
+docker load -i nginx.tar
+docker load < nginx.tar
+
+# コンテナをイメージに変換（export/import）
+docker export コンテナID > container.tar
+docker import container.tar my-image:1.0</code></pre>
+      <p>✓ <code>save/load</code>はイメージの履歴を保持します</p>
+      <p>✗ <code>export/import</code>は履歴が失われます</p>
+    </section>
+
+    <section>
+      <h2>イメージのサイズ確認</h2>
+      <pre><code class="language-bash"># イメージのサイズを確認
+docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+
+# 特定イメージのレイヤーサイズを確認
+docker history nginx
+
+# ディスク使用状況を確認
+docker system df
+docker system df -v</code></pre>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/tools/docker-cheatsheet">目次に戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: #333;
+    border-bottom: 2px solid #667eea;
+    padding-bottom: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  ul {
+    margin-bottom: 1rem;
+    padding-left: 2rem;
+  }
+
+  li {
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    line-height: 1.5;
+  }
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.9rem;
+  }
+
+  p code {
+    background: #f4f4f4;
+    color: #d63384;
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+
+  .page-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #667eea;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 1.1rem;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/pages/tools/docker-cheatsheet/images.astro
+++ b/src/pages/tools/docker-cheatsheet/images.astro
@@ -63,8 +63,8 @@ docker inspect nginx
 docker inspect イメージID
 
 # 特定の情報だけを取得
-docker inspect --format='{{.Config.Env}}' nginx
-docker inspect --format='{{.Architecture}}' nginx
+docker inspect --format='{"{{.Config.Env}}'"}' nginx
+docker inspect --format='{"{{.Architecture}}'"}' nginx
 
 # イメージの履歴を確認
 docker history nginx
@@ -183,7 +183,7 @@ docker load -i nginx.tar
 docker load < nginx.tar
 
 # コンテナをイメージに変換（export/import）
-docker export コンテナID > container.tar
+docker export コンテナ名 > container.tar
 docker import container.tar my-image:1.0</code></pre>
       <p>✓ <code>save/load</code>はイメージの履歴を保持します</p>
       <p>✗ <code>export/import</code>は履歴が失われます</p>
@@ -192,7 +192,7 @@ docker import container.tar my-image:1.0</code></pre>
     <section>
       <h2>イメージのサイズ確認</h2>
       <pre><code class="language-bash"># イメージのサイズを確認
-docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+docker images --format "table {"{{.Repository}}\t{{.Tag}}\t{{.Size}}'"}}"
 
 # 特定イメージのレイヤーサイズを確認
 docker history nginx

--- a/src/pages/tools/docker-cheatsheet/images.astro
+++ b/src/pages/tools/docker-cheatsheet/images.astro
@@ -63,8 +63,8 @@ docker inspect nginx
 docker inspect イメージID
 
 # 特定の情報だけを取得
-docker inspect --format='{"{{.Config.Env}}'"}' nginx
-docker inspect --format='{"{{.Architecture}}'"}' nginx
+docker inspect --format='&#123;&#123;.Config.Env&#125;&#125;' nginx
+docker inspect --format='&#123;&#123;.Architecture&#125;&#125;' nginx
 
 # イメージの履歴を確認
 docker history nginx
@@ -192,7 +192,7 @@ docker import container.tar my-image:1.0</code></pre>
     <section>
       <h2>イメージのサイズ確認</h2>
       <pre><code class="language-bash"># イメージのサイズを確認
-docker images --format "table {"{{.Repository}}\t{{.Tag}}\t{{.Size}}'"}}"
+docker images --format "table &#123;&#123;.Repository&#125;&#125;\t&#123;&#123;.Tag&#125;&#125;\t&#123;&#123;.Size&#125;&#125;"
 
 # 特定イメージのレイヤーサイズを確認
 docker history nginx

--- a/src/pages/tools/docker-cheatsheet/index.astro
+++ b/src/pages/tools/docker-cheatsheet/index.astro
@@ -1,0 +1,244 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+
+<Layout title="Dockerコマンドチートシート - 実務で使える完全ガイド">
+  <main>
+    <header class="page-header">
+      <h1>Dockerコマンドチートシート</h1>
+      <p class="subtitle">実務で使える完全リファレンス - 基礎から応用まで</p>
+      <div class="meta">
+        <span>最終更新: 2026年2月9日</span>
+      </div>
+    </header>
+
+    <section class="intro">
+      <h2>このチートシートについて</h2>
+      <p>
+        Dockerはコンテナ技術を用いた開発環境として、現代のソフトウェア開発において必須のツールです。
+        このチートシートでは、基本的なコマンドから高度な操作まで、
+        実務で役立つDockerコマンドを網羅的に解説します。
+      </p>
+      <p>
+        初心者から中級者まで、日々の開発業務ですぐに参照できるよう、
+        カテゴリ別に整理されたコマンド一覧と具体例を提供します。
+      </p>
+    </section>
+
+    <section class="categories">
+      <h2>カテゴリ一覧</h2>
+      
+      <div class="category-grid">
+        <a href="/tools/docker-cheatsheet/basics" class="category-card">
+          <h3>🚀 基本操作</h3>
+          <ul>
+            <li>Dockerの基本概念</li>
+            <li>インストール確認</li>
+            <li>基本コマンド</li>
+            <li>コンテナの起動と停止</li>
+          </ul>
+          <span class="read-more">詳しく見る →</span>
+        </a>
+
+        <a href="/tools/docker-cheatsheet/images" class="category-card">
+          <h3>📦 イメージ管理</h3>
+          <ul>
+            <li>イメージの検索と取得</li>
+            <li>イメージの一覧・削除</li>
+            <li>イメージのビルド</li>
+            <li>イメージの保存・読込</li>
+          </ul>
+          <span class="read-more">詳しく見る →</span>
+        </a>
+
+        <a href="/tools/docker-cheatsheet/containers" class="category-card">
+          <h3>🔧 コンテナ操作</h3>
+          <ul>
+            <li>コンテナの起動オプション</li>
+            <li>コンテナ内でのコマンド実行</li>
+            <li>ログとステータス確認</li>
+            <li>コンテナの停止・削除</li>
+          </ul>
+          <span class="read-more">詳しく見る →</span>
+        </a>
+
+        <a href="/tools/docker-cheatsheet/compose" class="category-card">
+          <h3>🐳 Docker Compose</h3>
+          <ul>
+            <li>docker-compose.ymlの基本</li>
+            <li>主要コマンド</li>
+            <li>よく使うオプション</li>
+            <li>実用例</li>
+          </ul>
+          <span class="read-more">詳しく見る →</span>
+        </a>
+
+        <a href="/tools/docker-cheatsheet/tips" class="category-card">
+          <h3>💡 Tips</h3>
+          <ul>
+            <li>クリーンアップコマンド</li>
+            <li>トラブルシューティング</li>
+            <li>ネットワーク・ボリューム管理</li>
+            <li>便利なTips</li>
+          </ul>
+          <span class="read-more">詳しく見る →</span>
+        </a>
+      </div>
+    </section>
+
+    <footer class="page-footer">
+      <p>各カテゴリをクリックして、詳細なコマンドとその使い方をご覧ください。</p>
+      <p><a href="/">トップページに戻る</a></p>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 2px solid #667eea;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .subtitle {
+    font-size: 1.1rem;
+    color: #666;
+    margin-bottom: 1rem;
+  }
+
+  .meta {
+    font-size: 0.9rem;
+    color: #888;
+  }
+
+  .intro {
+    background: #f8f9fa;
+    padding: 1.5rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .intro p {
+    margin-bottom: 1rem;
+  }
+
+  .intro p:last-child {
+    margin-bottom: 0;
+  }
+
+  .categories {
+    margin-bottom: 3rem;
+  }
+
+  .categories h2 {
+    text-align: center;
+    font-size: 1.8rem;
+    margin-bottom: 2rem;
+    color: #333;
+  }
+
+  .category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .category-card {
+    background: #fff;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-decoration: none;
+    color: inherit;
+    transition: all 0.3s ease;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .category-card:hover {
+    border-color: #667eea;
+    transform: translateY(-4px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+  }
+
+  .category-card h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: #667eea;
+    font-size: 1.3rem;
+  }
+
+  .category-card ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0 0 1rem 0;
+    flex-grow: 1;
+  }
+
+  .category-card ul li {
+    padding: 0.4rem 0;
+    color: #555;
+    font-size: 0.95rem;
+  }
+
+  .category-card ul li:before {
+    content: "▹ ";
+    color: #667eea;
+    font-weight: bold;
+  }
+
+  .read-more {
+    color: #667eea;
+    font-weight: 600;
+    font-size: 0.95rem;
+    margin-top: auto;
+  }
+
+  .page-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #667eea;
+    color: #666;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 768px) {
+    h1 {
+      font-size: 2rem;
+    }
+
+    .category-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/pages/tools/docker-cheatsheet/tips.astro
+++ b/src/pages/tools/docker-cheatsheet/tips.astro
@@ -1,0 +1,391 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import Navigation from '../../../components/docker-cheatsheet/Navigation.astro';
+---
+
+<Layout title="トラブルシューティング・Tips - Dockerコマンドチートシート">
+  <Navigation currentPage="/tools/docker-cheatsheet/tips" />
+  <main>
+    <h1>トラブルシューティング・Tips</h1>
+
+    <section>
+      <h2>クリーンアップ系コマンド</h2>
+      <p>Dockerを使い続けると、使われていないイメージやコンテナがたまります。定期的な掃除が重要です。</p>
+      <pre><code class="language-bash"># ディスク使用量を確認
+docker system df
+
+# 詳細情報を表示
+docker system df -v
+
+# 未使用の全リソースを一括削除
+docker system prune
+
+# 未使用イメージも含めて削除
+docker system prune -a
+
+# ボリュームも含めて削除（注意）
+docker system prune -a --volumes
+
+# 確認なしで実行
+docker system prune -af</code></pre>
+      <p>✓ 定期的に<code>prune</code>を実行してディスク容量を節約</p>
+      <p>✗ <code>--volumes</code>オプションはデータベースデータを削除する可能性があるので注意</p>
+    </section>
+
+    <section>
+      <h2>コンテナのクリーンアップ</h2>
+      <pre><code class="language-bash"># 停止中のコンテナを全て削除
+docker container prune
+
+# 全コンテナを停止
+docker stop $(docker ps -q)
+
+# 全コンテナを削除
+docker rm $(docker ps -aq)
+
+# 実行中の全コンテナを強制停止・削除
+docker rm -f $(docker ps -aq)</code></pre>
+    </section>
+
+    <section>
+      <h2>イメージのクリーンアップ</h2>
+      <pre><code class="language-bash"># 未使用イメージを削除
+docker image prune
+
+# タグなしイメージ（dangling）を削除
+docker image prune
+
+# 未使用の全イメージを削除
+docker image prune -a
+
+# タグなしイメージのみ一括削除
+docker rmi $(docker images -f "dangling=true" -q)
+
+# 全イメージを削除（注意）
+docker rmi $(docker images -q)</code></pre>
+    </section>
+
+    <section>
+      <h2>ボリュームの管理</h2>
+      <pre><code class="language-bash"># ボリューム一覧
+docker volume ls
+
+# ボリュームの詳細情報
+docker volume inspect ボリューム名
+
+# ボリュームを作成
+docker volume create my-volume
+
+# 未使用ボリュームを削除
+docker volume prune
+
+# 特定のボリュームを削除
+docker volume rm ボリューム名
+
+# 全ボリュームを削除（非常に危険）
+docker volume rm $(docker volume ls -q)</code></pre>
+      <p>※ ボリュームはデータを保持するため、削除前に必ず確認してください。</p>
+    </section>
+
+    <section>
+      <h2>ネットワークの管理</h2>
+      <pre><code class="language-bash"># ネットワーク一覧
+docker network ls
+
+# ネットワークの詳細情報
+docker network inspect bridge
+
+# ネットワークを作成
+docker network create my-network
+
+# コンテナをネットワークに接続
+docker network connect my-network コンテナ名
+
+# コンテナをネットワークから切断
+docker network disconnect my-network コンテナ名
+
+# 未使用ネットワークを削除
+docker network prune
+
+# ネットワークを削除
+docker network rm my-network</code></pre>
+    </section>
+
+    <section>
+      <h2>よくあるトラブルと対処法</h2>
+      
+      <h3>ポートがすでに使用されている</h3>
+      <pre><code class="language-bash"># エラー例: Error starting userland proxy: listen tcp4 0.0.0.0:8080: bind: address already in use
+
+# 対処方法1: 使用中のプロセスを確認
+lsof -i :8080
+# または
+netstat -an | grep 8080
+
+# 対処方法2: 別のポートを使用
+docker run -d -p 8081:80 nginx
+
+# 対処方法3: 使用中のコンテナを停止
+docker ps | grep 8080
+docker stop コンテナ名</code></pre>
+
+      <h3>イメージが削除できない</h3>
+      <pre><code class="language-bash"># エラー例: Error response from daemon: conflict: unable to remove repository reference
+
+# 対処方法1: 使用中のコンテナを確認・削除
+docker ps -a | grep イメージ名
+docker rm -f コンテナ名
+
+# 対処方法2: 強制削除
+docker rmi -f イメージID</code></pre>
+
+      <h3>コンテナが起動しない</h3>
+      <pre><code class="language-bash"># ログを確認
+docker logs コンテナ名
+
+# 詳細情報を確認
+docker inspect コンテナ名
+
+# イベントを確認
+docker events --since 1h
+
+# コンテナを再作成
+docker rm コンテナ名
+docker run [OPTIONS] イメージ名</code></pre>
+
+      <h3>ボリュームのパーミッションエラー</h3>
+      <pre><code class="language-bash"># エラー例: Permission denied
+
+# 対処方法1: ユーザーIDを指定
+docker run -u $(id -u):$(id -g) -v $(pwd):/app イメージ名
+
+# 対処方法2: ホスト側のパーミッションを変更
+chmod -R 755 ./data
+
+# 対処方法3: SELinuxが原因の場合（Linux）
+docker run -v $(pwd):/app:z イメージ名</code></pre>
+
+      <h3>Dockerデーモンが起動しない</h3>
+      <pre><code class="language-bash"># Dockerデーモンの状態確認
+sudo systemctl status docker
+
+# Dockerデーモンを再起動
+sudo systemctl restart docker
+
+# Dockerデーモンを有効化
+sudo systemctl enable docker
+
+# macOS/Windowsの場合：Docker Desktopを再起動</code></pre>
+    </section>
+
+    <section>
+      <h2>便利なTips</h2>
+
+      <h3>コンテナ内でシェルを起動</h3>
+      <pre><code class="language-bash"># bashを起動
+docker exec -it コンテナ名 bash
+
+# shを起動（Alpine Linuxなど）
+docker exec -it コンテナ名 sh
+
+# rootユーザーで接続
+docker exec -it -u root コンテナ名 bash
+
+# 新規コンテナでシェル起動
+docker run -it --rm ubuntu bash</code></pre>
+
+      <h3>ログを見やすく表示</h3>
+      <pre><code class="language-bash"># リアルタイムでログを追跡
+docker logs -f コンテナ名
+
+# 最新100行を表示
+docker logs --tail 100 コンテナ名
+
+# タイムスタンプ付きで表示
+docker logs -t コンテナ名
+
+# 特定時間以降のログ
+docker logs --since 2h コンテナ名
+docker logs --since 2024-01-01T00:00:00 コンテナ名</code></pre>
+
+      <h3>コンテナのリソース使用状況を監視</h3>
+      <pre><code class="language-bash"># 全コンテナのリソース使用状況
+docker stats
+
+# 特定コンテナのみ監視
+docker stats コンテナ名
+
+# ストリームしない（一回のみ表示）
+docker stats --no-stream
+
+# 実行中のプロセスを表示
+docker top コンテナ名</code></pre>
+
+      <h3>ファイルのコピー</h3>
+      <pre><code class="language-bash"># ホストからコンテナへ
+docker cp ./local-file.txt コンテナ名:/path/to/
+
+# コンテナからホストへ
+docker cp コンテナ名:/path/to/file.txt ./
+
+# ディレクトリごとコピー
+docker cp コンテナ名:/app/logs ./logs</code></pre>
+
+      <h3>イメージのエクスポート・インポート</h3>
+      <pre><code class="language-bash"># イメージをtarファイルに保存
+docker save -o my-image.tar イメージ名
+
+# tarファイルからイメージを読み込み
+docker load -i my-image.tar
+
+# 複数イメージを一括保存
+docker save -o images.tar イメージ1 イメージ2</code></pre>
+
+      <h3>エイリアスを使用した短縮コマンド</h3>
+      <pre><code class="language-bash"># ~/.bashrc または ~/.zshrc に追加
+
+# コンテナ一覧
+alias dps='docker ps'
+alias dpsa='docker ps -a'
+
+# クリーンアップ
+alias dprune='docker system prune -af'
+
+# コンテナを停止・削除
+alias dstop='docker stop $(docker ps -q)'
+alias drm='docker rm $(docker ps -aq)'
+
+# Docker Compose
+alias dc='docker compose'
+alias dcu='docker compose up -d'
+alias dcd='docker compose down'
+alias dcl='docker compose logs -f'</code></pre>
+    </section>
+
+    <section>
+      <h2>セキュリティのベストプラクティス</h2>
+      <ul>
+        <li><strong>rootユーザーを避ける</strong>：コンテナ内では非rootユーザーを使用</li>
+        <li><strong>最小限のイメージを使用</strong>：Alpine Linuxなど軽量イメージを選ぶ</li>
+        <li><strong>イメージを定期的に更新</strong>：セキュリティパッチを適用</li>
+        <li><strong>シークレットをハードコードしない</strong>：環境変数やDocker Secretsを使用</li>
+        <li><strong>コンテナのリソースを制限</strong>：<code>--memory</code>や<code>--cpus</code>で制限</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>デバッグ用コマンド</h2>
+      <pre><code class="language-bash"># コンテナの全詳細情報をJSON形式で表示
+docker inspect コンテナ名
+
+# 特定の情報だけ抽出
+docker inspect --format='{{.NetworkSettings.IPAddress}}' コンテナ名
+
+# コンテナのプロセス一覧
+docker top コンテナ名
+
+# コンテナの変更点を確認
+docker diff コンテナ名
+
+# イメージの履歴を確認
+docker history イメージ名</code></pre>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/tools/docker-cheatsheet">目次に戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: #333;
+    border-bottom: 2px solid #667eea;
+    padding-bottom: 0.5rem;
+  }
+
+  h3 {
+    font-size: 1.4rem;
+    margin-top: 2rem;
+    margin-bottom: 0.8rem;
+    color: #444;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  ul {
+    margin-bottom: 1rem;
+    padding-left: 2rem;
+  }
+
+  li {
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    line-height: 1.5;
+  }
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.9rem;
+  }
+
+  p code {
+    background: #f4f4f4;
+    color: #d63384;
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+
+  .page-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #667eea;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 1.1rem;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/pages/tools/docker-cheatsheet/tips.astro
+++ b/src/pages/tools/docker-cheatsheet/tips.astro
@@ -279,7 +279,7 @@ alias dcl='docker compose logs -f'</code></pre>
 docker inspect コンテナ名
 
 # 特定の情報だけ抽出
-docker inspect --format='{{.NetworkSettings.IPAddress}}' コンテナ名
+docker inspect --format='&#123;&#123;.NetworkSettings.IPAddress&#125;&#125;' コンテナ名
 
 # コンテナのプロセス一覧
 docker top コンテナ名


### PR DESCRIPTION
## 概要
Dockerコマンドチートシートを新規追加しました。

## 追加したコンテンツ

### ページ構成（6ページ）
1. **index.astro** - 目次ページ
2. **basics.astro** - 基本操作（Dockerの概念、コンテナの起動・停止・削除など）
3. **images.astro** - イメージ管理（検索、取得、ビルド、保存など）
4. **containers.astro** - コンテナ操作（起動オプション、exec、logsなど）
5. **compose.astro** - Docker Compose（複数コンテナの管理）
6. **tips.astro** - トラブルシューティング・Tips

### 主な内容
- Dockerコマンドの実用例を豊富に収録
- 初心者から中級者まで対応
- よくあるトラブルとその対処法
- クリーンアップ系コマンドのまとめ
- Docker Composeの実用例

## 変更内容
- ✅ `src/pages/tools/docker-cheatsheet/` ディレクトリを作成
- ✅ 6つの.astroファイルを追加
- ✅ トップページにDockerチートシートへのリンクを追加

## デザイン
- 既存のGit/SQLチートシートと同じデザインパターンを踏襲
- カラーパレット：#667eea（紫青）、#764ba2（紫）
- レスポンシブ対応済み

## 確認事項
- [ ] 各ページが正しく表示されるか
- [ ] ナビゲーションが機能するか
- [ ] トップページからのリンクが機能するか
- [ ] レスポンシブデザインが機能するか

## デプロイ後の確認URL
- https://hrstsh.github.io/tools/docker-cheatsheet/
- https://hrstsh.github.io/tools/docker-cheatsheet/basics
- https://hrstsh.github.io/tools/docker-cheatsheet/images
- https://hrstsh.github.io/tools/docker-cheatsheet/containers
- https://hrstsh.github.io/tools/docker-cheatsheet/compose
- https://hrstsh.github.io/tools/docker-cheatsheet/tips