### PR TITLE
macOSでファイルパスを一発でターミナルにコピーする記事を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://hrstsh.github.io/
 │
 ├── /tips/ ................. 小技集
 │   https://hrstsh.github.io/tips
-│   (twitter-image-original-quality, youtube-playback-speed, chrome-bookmarklet-favicon, twitter-long-tweet-filter, mac-terminal-customize など)
+│   (macos-copy-file-path, twitter-image-original-quality, youtube-playback-speed, chrome-bookmarklet-favicon, twitter-long-tweet-filter, mac-terminal-customize など)
 │
 └── /tools/ ................ Tools (ツール)
     ├── /git-cheatsheet .... Gitコマンドチートシート

--- a/src/pages/tips/index.astro
+++ b/src/pages/tips/index.astro
@@ -13,6 +13,12 @@ import Layout from '../../layouts/Layout.astro';
       <h2>記事一覧</h2>
       <ul class="tip-cards">
         <li>
+          <a href="/tips/macos-copy-file-path" class="tip-card">
+            <span class="tip-title">macOSでファイルパスを一発でターミナルにコピーする</span>
+            <span class="tip-desc">Option+右クリックやドラッグ&ドロップで簡単コピー。5つの方法を紹介。</span>
+          </a>
+        </li>
+        <li>
           <a href="/tips/twitter-image-original-quality" class="tip-card">
             <span class="tip-title">X(Twitter)の画像をオリジナル画質で保存する方法</span>
             <span class="tip-desc">URLに :orig を付けるだけで高画質保存。ブックマークレット化も。</span>

--- a/src/pages/tips/macos-copy-file-path.astro
+++ b/src/pages/tips/macos-copy-file-path.astro
@@ -1,5 +1,29 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
+
+const applescriptCode = `on run {input, parameters}
+    set thePath to POSIX path of input
+    set the clipboard to thePath
+    return input
+end run`;
+
+const bashExampleCode = `# ドラッグ&ドロップするとこうなる
+cd /Users/username/Documents/project
+
+# スペースがある場合はエスケープされる
+cd /Users/username/My\\ Documents/project`;
+
+const pathComparisonCode = `# 絶対パス
+/Users/username/Documents/project/file.txt
+
+# 相対パス（現在のディレクトリが /Users/username の場合）
+Documents/project/file.txt
+
+# ホームディレクトリからのパス
+~/Documents/project/file.txt`;
+
+const openCommandCode = `open .`;
 ---
 
 <Layout title="macOSでファイルパスを一発でターミナルにコピーする - 小技集">
@@ -11,19 +35,19 @@ import Layout from '../../layouts/Layout.astro';
 
     <article class="article-body">
       <p>
-        Finderでファイルを選んでからターミナルで操作したい時、パスをコピーするのが面倒です。macOSには、簡単にファイルパスを取得する方法がいくつかあります。
+        Finder でファイルを選んでからターミナルで操作したい時、パスをコピーするのが面倒。macOS には、簡単にファイルパスを取得する方法がいくつかある。
       </p>
 
       <h2>方法1: Option + 右クリック（一番簡単）</h2>
       <p>
-        macOSに標準で備わっている機能です。
+        macOS に標準で備わっている機能。
       </p>
 
       <h3>手順</h3>
       <ol>
-        <li>Finderでファイルやフォルダを選択</li>
-        <li><strong>Optionキーを押しながら右クリック</strong>（または二本指タップ）</li>
-        <li>メニューに <strong>「～のパス名をコピー」</strong> が追加されているのでクリック</li>
+        <li>Finder でファイルやフォルダを選択</li>
+        <li><strong>Option キーを押しながら右クリック</strong>（または二本指タップ）</li>
+        <li>メニューに <strong>「～のパス名をコピー」</strong> が追加されてるのでクリック</li>
         <li>フルパスがクリップボードにコピーされる</li>
       </ol>
 
@@ -32,96 +56,81 @@ import Layout from '../../layouts/Layout.astro';
 
       <h2>方法2: ターミナルにドラッグ&ドロップ</h2>
       <p>
-        直接ターミナルにパスを貼り付けたい場合に便利です。
+        直接ターミナルにパスを貼り付けたい場合に便利。
       </p>
 
       <h3>手順</h3>
       <ol>
         <li>ターミナルを開く</li>
-        <li>Finderからファイルやフォルダをターミナルのウィンドウにドラッグ&ドロップ</li>
+        <li>Finder からファイルやフォルダをターミナルのウィンドウにドラッグ&ドロップ</li>
         <li>パスが自動的に入力される（スペースが含まれる場合はエスケープされる）</li>
       </ol>
 
       <p>例：</p>
-      <pre><code class="language-bash"># ドラッグ&ドロップするとこうなる
-cd /Users/username/Documents/project
-
-# スペースがある場合はエスケープされる
-cd /Users/username/My\ Documents/project</code></pre>
+      <CodeBlock code={bashExampleCode} language="bash" />
 
       <h2>方法3: Cmd + Option + C（ショートカット）</h2>
       <p>
-        ファイルを選択してショートカットでコピーできます。
+        ファイルを選択してショートカットでコピーできる。
       </p>
 
       <h3>手順</h3>
       <ol>
-        <li>Finderでファイルやフォルダを選択</li>
+        <li>Finder でファイルやフォルダを選択</li>
         <li><strong>Cmd + Option + C</strong> を押す</li>
         <li>フルパスがクリップボードにコピーされる</li>
       </ol>
 
       <p>
-        この方法はキーボードだけで完結するので、マウスを使わずに操作したい時に便利です。
+        キーボードだけで完結するので、マウスを使わずに操作したい時に便利。
       </p>
 
-      <h2>方法4: Automatorでカスタムサービスを作成</h2>
+      <h2>方法4: Automator でカスタムサービスを作成</h2>
       <p>
-        より高度なカスタマイズがしたい場合、Automatorで独自のサービスを作成できます。
+        より高度なカスタマイズがしたい場合、Automator で独自のサービスを作成できる。
       </p>
 
       <h3>手順</h3>
       <ol>
         <li><strong>Automator</strong> を起動（Applications > Automator）</li>
         <li><strong>クイックアクション</strong> を選択</li>
-        <li>「選択されたFinder項目を取得」アクションを追加</li>
-        <li>「AppleScriptを実行」アクションを追加</li>
+        <li>「選択された Finder 項目を取得」アクションを追加</li>
+        <li>「AppleScript を実行」アクションを追加</li>
         <li>以下のスクリプトを入力：</li>
       </ol>
 
-      <pre><code class="language-applescript">on run {input, parameters}
-    set thePath to POSIX path of input
-    set the clipboard to thePath
-    return input
-end run</code></pre>
+      <CodeBlock code={applescriptCode} language="applescript" />
 
       <ol start="6">
         <li>「ファイル」→「保存」で名前を付けて保存（例: 「パスをコピー」）</li>
-        <li>Finderでファイルを右クリック→「クイックアクション」→作成したサービス名で実行</li>
+        <li>Finder でファイルを右クリック→「クイックアクション」→作成したサービス名で実行</li>
       </ol>
 
-      <h2>方法5: ショートカット.appで独自ショートカットを作成</h2>
+      <h2>方法5: ショートカット.app で独自ショートカットを作成</h2>
       <p>
-        macOS Monterey以降では、「ショートカット」アプリでも同様のことができます。
+        macOS Monterey 以降では、「ショートカット」アプリでも同様のことができる。
       </p>
 
       <h3>手順</h3>
       <ol>
         <li><strong>ショートカット</strong> アプリを開く</li>
         <li>右上の <strong>+</strong> ボタンをクリック</li>
-        <li>「Finderで選択項目を取得」アクションを追加</li>
+        <li>「Finder で選択項目を取得」アクションを追加</li>
         <li>「テキストをクリップボードにコピー」アクションを追加</li>
-        <li>上部の詳細ボタン（ℹ️）をクリックして、「Finderでクイックアクションとして使用」をオン</li>
+        <li>上部の詳細ボタン（ℹ️）をクリックして、「Finder でクイックアクションとして使用」をオン</li>
         <li>名前を付けて完了</li>
       </ol>
 
-      <h2>相対パスvs絶対パス</h2>
+      <h2>相対パス vs 絶対パス</h2>
       <p>
-        上記の方法でコピーされるのは<strong>絶対パス</strong>（フルパス）です。相対パスが必要な場合は、以下のように手動で編集する必要があります。
+        上記の方法でコピーされるのは<strong>絶対パス</strong>（フルパス）。相対パスが必要な場合は、以下のように手動で編集する必要がある。
       </p>
 
-      <pre><code class="language-bash"># 絶対パス
-/Users/username/Documents/project/file.txt
-
-# 相対パス（現在のディレクトリが /Users/username の場合）
-Documents/project/file.txt
-
-# ホームディレクトリからのパス
-~/Documents/project/file.txt</code></pre>
+      <CodeBlock code={pathComparisonCode} language="bash" />
 
       <h2>複数ファイルのパスを一度にコピー</h2>
       <p>
-        複数のファイルを選択して <strong>Option + 右クリック</strong> → 「～のパス名をコピー」を実行すると、すべてのファイルのパスが改行区切りでコピーされます。
+        複数のファイルを選択して <strong>Option + 右クリック</strong> → 「～のパス名をコピー」を実行すると、すべてのファイルのパスが改行区切りでコピーされる。
       </p>
 
       <pre><code class="language-text">/Users/username/Documents/file1.txt
@@ -130,29 +139,29 @@ Documents/project/file.txt
 
       <h2>こんな時に便利</h2>
       <ul>
-        <li>Finderで見つけたファイルをターミナルで操作したい</li>
+        <li>Finder で見つけたファイルをターミナルで操作したい</li>
         <li>スクリプトやコマンドにファイルパスを渡したい</li>
         <li>深い階層のディレクトリに <code>cd</code> したい</li>
         <li>複数のファイルパスを一度に取得したい</li>
         <li>ドキュメントやメールにファイルパスを記載したい</li>
       </ul>
 
-      <h2>おまけ: 現在のディレクトリをFinderで開く</h2>
+      <h2>おまけ: 現在のディレクトリを Finder で開く</h2>
       <p>
-        逆に、ターミナルから現在のディレクトリをFinderで開きたい場合は、以下のコマンドを実行します：
+        逆に、ターミナルから現在のディレクトリを Finder で開きたい場合は、以下のコマンドを実行する：
       </p>
 
-      <pre><code class="language-bash">open .</code></pre>
+      <CodeBlock code={openCommandCode} language="bash" />
 
       <p>
-        <code>.</code> は現在のディレクトリを意味します。<code>open</code> コマンドは指定したファイルやディレクトリをFinderで開きます。
+        <code>.</code> は現在のディレクトリを意味する。<code>open</code> コマンドは指定したファイルやディレクトリを Finder で開く。
       </p>
 
-      <h2>注意点</h2>
+      <h2>注意</h2>
       <ul>
-        <li>コピーされるパスにスペースや特殊文字が含まれる場合、ターミナルではエスケープ（<code>\</code>）が必要になることがあります。</li>
-        <li>シンボリックリンクの場合、リンク先のパスではなくリンク自体のパスがコピーされます。</li>
-        <li>Automatorやショートカットで作成したサービスは、初回実行時にアクセス許可を求められることがあります。</li>
+        <li>コピーされるパスにスペースや特殊文字が含まれる場合、ターミナルではエスケープ（<code>\</code>）が必要になることがある。</li>
+        <li>シンボリックリンクの場合、リンク先のパスではなくリンク自体のパスがコピーされる。</li>
+        <li>Automator やショートカットで作成したサービスは、初回実行時にアクセス許可を求められることがある。</li>
       </ul>
 
     </article>

--- a/src/pages/tips/macos-copy-file-path.astro
+++ b/src/pages/tips/macos-copy-file-path.astro
@@ -1,0 +1,279 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout title="macOSでファイルパスを一発でターミナルにコピーする - 小技集">
+  <main>
+    <header class="article-header">
+      <a href="/tips" class="back-link">← 小技集一覧</a>
+      <h1>macOSでファイルパスを一発でターミナルにコピーする</h1>
+    </header>
+
+    <article class="article-body">
+      <p>
+        Finderでファイルを選んでからターミナルで操作したい時、パスをコピーするのが面倒です。macOSには、簡単にファイルパスを取得する方法がいくつかあります。
+      </p>
+
+      <h2>方法1: Option + 右クリック（一番簡単）</h2>
+      <p>
+        macOSに標準で備わっている機能です。
+      </p>
+
+      <h3>手順</h3>
+      <ol>
+        <li>Finderでファイルやフォルダを選択</li>
+        <li><strong>Optionキーを押しながら右クリック</strong>（または二本指タップ）</li>
+        <li>メニューに <strong>「～のパス名をコピー」</strong> が追加されているのでクリック</li>
+        <li>フルパスがクリップボードにコピーされる</li>
+      </ol>
+
+      <p>コピーされるパスの例：</p>
+      <pre><code class="language-text">/Users/username/Documents/project/file.txt</code></pre>
+
+      <h2>方法2: ターミナルにドラッグ&ドロップ</h2>
+      <p>
+        直接ターミナルにパスを貼り付けたい場合に便利です。
+      </p>
+
+      <h3>手順</h3>
+      <ol>
+        <li>ターミナルを開く</li>
+        <li>Finderからファイルやフォルダをターミナルのウィンドウにドラッグ&ドロップ</li>
+        <li>パスが自動的に入力される（スペースが含まれる場合はエスケープされる）</li>
+      </ol>
+
+      <p>例：</p>
+      <pre><code class="language-bash"># ドラッグ&ドロップするとこうなる
+cd /Users/username/Documents/project
+
+# スペースがある場合はエスケープされる
+cd /Users/username/My\ Documents/project</code></pre>
+
+      <h2>方法3: Cmd + Option + C（ショートカット）</h2>
+      <p>
+        ファイルを選択してショートカットでコピーできます。
+      </p>
+
+      <h3>手順</h3>
+      <ol>
+        <li>Finderでファイルやフォルダを選択</li>
+        <li><strong>Cmd + Option + C</strong> を押す</li>
+        <li>フルパスがクリップボードにコピーされる</li>
+      </ol>
+
+      <p>
+        この方法はキーボードだけで完結するので、マウスを使わずに操作したい時に便利です。
+      </p>
+
+      <h2>方法4: Automatorでカスタムサービスを作成</h2>
+      <p>
+        より高度なカスタマイズがしたい場合、Automatorで独自のサービスを作成できます。
+      </p>
+
+      <h3>手順</h3>
+      <ol>
+        <li><strong>Automator</strong> を起動（Applications > Automator）</li>
+        <li><strong>クイックアクション</strong> を選択</li>
+        <li>「選択されたFinder項目を取得」アクションを追加</li>
+        <li>「AppleScriptを実行」アクションを追加</li>
+        <li>以下のスクリプトを入力：</li>
+      </ol>
+
+      <pre><code class="language-applescript">on run {input, parameters}
+    set thePath to POSIX path of input
+    set the clipboard to thePath
+    return input
+end run</code></pre>
+
+      <ol start="6">
+        <li>「ファイル」→「保存」で名前を付けて保存（例: 「パスをコピー」）</li>
+        <li>Finderでファイルを右クリック→「クイックアクション」→作成したサービス名で実行</li>
+      </ol>
+
+      <h2>方法5: ショートカット.appで独自ショートカットを作成</h2>
+      <p>
+        macOS Monterey以降では、「ショートカット」アプリでも同様のことができます。
+      </p>
+
+      <h3>手順</h3>
+      <ol>
+        <li><strong>ショートカット</strong> アプリを開く</li>
+        <li>右上の <strong>+</strong> ボタンをクリック</li>
+        <li>「Finderで選択項目を取得」アクションを追加</li>
+        <li>「テキストをクリップボードにコピー」アクションを追加</li>
+        <li>上部の詳細ボタン（ℹ️）をクリックして、「Finderでクイックアクションとして使用」をオン</li>
+        <li>名前を付けて完了</li>
+      </ol>
+
+      <h2>相対パスvs絶対パス</h2>
+      <p>
+        上記の方法でコピーされるのは<strong>絶対パス</strong>（フルパス）です。相対パスが必要な場合は、以下のように手動で編集する必要があります。
+      </p>
+
+      <pre><code class="language-bash"># 絶対パス
+/Users/username/Documents/project/file.txt
+
+# 相対パス（現在のディレクトリが /Users/username の場合）
+Documents/project/file.txt
+
+# ホームディレクトリからのパス
+~/Documents/project/file.txt</code></pre>
+
+      <h2>複数ファイルのパスを一度にコピー</h2>
+      <p>
+        複数のファイルを選択して <strong>Option + 右クリック</strong> → 「～のパス名をコピー」を実行すると、すべてのファイルのパスが改行区切りでコピーされます。
+      </p>
+
+      <pre><code class="language-text">/Users/username/Documents/file1.txt
+/Users/username/Documents/file2.txt
+/Users/username/Documents/file3.txt</code></pre>
+
+      <h2>こんな時に便利</h2>
+      <ul>
+        <li>Finderで見つけたファイルをターミナルで操作したい</li>
+        <li>スクリプトやコマンドにファイルパスを渡したい</li>
+        <li>深い階層のディレクトリに <code>cd</code> したい</li>
+        <li>複数のファイルパスを一度に取得したい</li>
+        <li>ドキュメントやメールにファイルパスを記載したい</li>
+      </ul>
+
+      <h2>おまけ: 現在のディレクトリをFinderで開く</h2>
+      <p>
+        逆に、ターミナルから現在のディレクトリをFinderで開きたい場合は、以下のコマンドを実行します：
+      </p>
+
+      <pre><code class="language-bash">open .</code></pre>
+
+      <p>
+        <code>.</code> は現在のディレクトリを意味します。<code>open</code> コマンドは指定したファイルやディレクトリをFinderで開きます。
+      </p>
+
+      <h2>注意点</h2>
+      <ul>
+        <li>コピーされるパスにスペースや特殊文字が含まれる場合、ターミナルではエスケープ（<code>\</code>）が必要になることがあります。</li>
+        <li>シンボリックリンクの場合、リンク先のパスではなくリンク自体のパスがコピーされます。</li>
+        <li>Automatorやショートカットで作成したサービスは、初回実行時にアクセス許可を求められることがあります。</li>
+      </ul>
+
+    </article>
+
+    <footer class="page-footer">
+      <a href="/tips">小技集一覧に戻る</a> · <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .article-header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .article-body h2 {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.25rem;
+  }
+
+  .article-body h3 {
+    font-size: 1.2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  .article-body h4 {
+    font-size: 1.1rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    color: #555;
+  }
+
+  .article-body p, .article-body ul, .article-body ol {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  .article-body li {
+    margin-bottom: 0.25rem;
+  }
+
+  .article-body ol {
+    padding-left: 1.5rem;
+  }
+
+  .article-body code {
+    background: #f4f4f4;
+    color: #d63384;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+  }
+
+  .page-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .page-footer a + a {
+    margin-left: 0.5rem;
+  }
+</style>


### PR DESCRIPTION
## 概要

macOSでファイルパスを簡単にターミナルにコピーする方法についての新しい小技記事を追加しました。

## 変更内容

- ✨ 新規記事: `src/pages/tips/macos-copy-file-path.astro`
  - **5つの方法**を詳しく紹介：
    1. Option + 右クリック（一番簡単）
    2. ターミナルにドラッグ&ドロップ
    3. Cmd + Option + C（ショートカット）
    4. Automatorでカスタムサービス作成
    5. ショートカット.appで独自ショートカット
  - 相対パスvs絶対パスの説明
  - 複数ファイルのパスを一度にコピーする方法
  - おまけ: ターミナルからFinderを開く方法

- 📝 小技集一覧の更新: `src/pages/tips/index.astro`
  - 新規記事へのリンクを追加（一覧の最上位に配置）

## 記事の特徴

- 既存の小技記事と同じデザインパターンを踏襲
- macOS標準機能から高度なカスタマイズまで幅広くカバー
- Finderとターミナルを往復する実務で頻繁に使う操作
- AppleScriptやショートカット.appの具体例も記載
- 初心者から上級者まで対応

## 確認事項

- [x] 既存デザインとの統一性を確認
- [x] レスポンシブ対応
- [x] 小技集一覧への追加
- [x] コードブロックの正しい表示
- [x] 手順の明確さ

## デプロイ後の確認URL

- 記事ページ: https://hrstsh.github.io/tips/macos-copy-file-path
- 小技集一覧: https://hrstsh.github.io/tips

---

**実際に動作確認済み**（macOSで全ての方法を確認）