### PR TITLE
sitemap を sitemap.xml に戻して標準形式を維持

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://hrstsh.github.io/sitemap-v2.xml
+Sitemap: https://hrstsh.github.io/sitemap.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Build 後に dist/ 内の HTML から URL を収集し、sitemap-v2.xml を生成する。
+ * Build 後に dist/ 内の HTML から URL を収集し、sitemap.xml を生成する。
  * Astro の @astrojs/sitemap が CI で _routes undefined になる問題の代替。
  */
 import { readdirSync, statSync, writeFileSync } from 'node:fs';
@@ -65,8 +65,8 @@ ${sorted.map(([path, lastmod]) => {
 </urlset>
 `;
 
-writeFileSync(join(distDir, 'sitemap-v2.xml'), xml, 'utf8');
-console.log('Generated dist/sitemap-v2.xml with', sorted.length, 'URLs');
+writeFileSync(join(distDir, 'sitemap.xml'), xml, 'utf8');
+console.log('Generated dist/sitemap.xml with', sorted.length, 'URLs');
 
 function escapeXml(s) {
   return s


### PR DESCRIPTION
Google Search Console での新しいファイル名の認識問題を回避。
sitemap.xml の内容は改善版（XMLスキーマ、lastmod タグ）を維持。