### PR TITLE
sitemap を年ベースのファイル名に変更 (sitemap-2026.xml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ Helper scripts for Git workflow (run from repository root):
 
 ## SEO
 
-- **Sitemap**: Generated at build time by `scripts/generate-sitemap.js` (output: `/sitemap.xml`). The script runs after `astro build` and scans `dist/` for pages.
-- **robots.txt**: `public/robots.txt` allows all crawlers and points to `https://hrstsh.github.io/sitemap.xml`.
+- **Sitemap**: Generated at build time by `scripts/generate-sitemap.js` (output: `/sitemap-YYYY.xml`, 例: `/sitemap-2026.xml`). The script runs after `astro build` and scans `dist/` for pages.
+  - 年ベースのファイル名で Google Search Console のキャッシュ問題を回避
+  - 各ページの `<lastmod>` タグに最終更新日を含む
+  - 標準的な XML 形式（スキーマ定義、適切なインデント）
+- **robots.txt**: `public/robots.txt` の Sitemap URL を毎年更新する必要があります（例: `https://hrstsh.github.io/sitemap-2026.xml`）
 
 ## Security
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://hrstsh.github.io/sitemap.xml
+Sitemap: https://hrstsh.github.io/sitemap-2026.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Build 後に dist/ 内の HTML から URL を収集し、sitemap.xml を生成する。
+ * Build 後に dist/ 内の HTML から URL を収集し、sitemap-YYYY.xml を生成する。
  * Astro の @astrojs/sitemap が CI で _routes undefined になる問題の代替。
  */
 import { readdirSync, statSync, writeFileSync } from 'node:fs';
@@ -10,6 +10,9 @@ import { fileURLToPath } from 'node:url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const distDir = join(__dirname, '..', 'dist');
 const site = 'https://hrstsh.github.io';
+// 年ベースのファイル名（Google Search Console のキャッシュ回避）
+const year = new Date().getFullYear();
+const sitemapFilename = `sitemap-${year}.xml`;
 
 function collectPaths(dir, base = '') {
   const entries = readdirSync(dir, { withFileTypes: true });
@@ -65,8 +68,11 @@ ${sorted.map(([path, lastmod]) => {
 </urlset>
 `;
 
-writeFileSync(join(distDir, 'sitemap.xml'), xml, 'utf8');
-console.log('Generated dist/sitemap.xml with', sorted.length, 'URLs');
+writeFileSync(join(distDir, sitemapFilename), xml, 'utf8');
+console.log(`Generated dist/${sitemapFilename} with`, sorted.length, 'URLs');
+console.log('');
+console.log('⚠️  重要: robots.txt を手動で更新してください');
+console.log(`   Sitemap: ${site}/${sitemapFilename}`);
 
 function escapeXml(s) {
   return s


### PR DESCRIPTION
Google Search Console のキャッシュ問題を根本的に解決。
同じ URL では古いデータが表示され続けるため、年ごとに異なる URL を使用。

- scripts/generate-sitemap.js: sitemap-YYYY.xml 形式で生成
- public/robots.txt: sitemap-2026.xml を指定
- README.md: sitemap の命名規則を説明