### PR TITLE
Google Analytics 4 (GA4) を導入

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,15 @@ const { title } = Astro.props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P4KH9E143V"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P4KH9E143V');
+    </script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
追加内容:
- Layout.astro に GA4 トラッキングコードを追加
- 測定ID: G-P4KH9E143V
- is:inline 属性を使用して静的サイトでも動作するよう設定

機能:
- 全ページのアクセス状況を自動追跡
- ページビュー、ユーザー数、滞在時間などを測定
- Google Analytics 管理画面で確認可能