### PR TITLE
GA4 をローカル開発環境では無効化

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ interface Props {
 }
 
 const { title } = Astro.props;
+const isProd = import.meta.env.PROD; // 本番環境判定
 ---
 
 <!doctype html>
@@ -19,14 +20,18 @@ const { title } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     
-    <!-- Google Analytics 4 -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P4KH9E143V"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-P4KH9E143V');
-    </script>
+    <!-- Google Analytics 4 (本番環境のみ) -->
+    {isProd && (
+      <>
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-P4KH9E143V"></script>
+        <script is:inline>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-P4KH9E143V');
+        </script>
+      </>
+    )}
   </head>
   <body>
     <slot />


### PR DESCRIPTION
変更内容:
- import.meta.env.PROD で本番環境を判定
- 本番ビルド時のみ GA4 スクリプトを読み込む
- ローカル開発 (npm run dev) では GA4 が動作しない

メリット:
- ローカルでのテストアクセスがデータを汚染しない
- 開発中のページビューが集計されない
- 本番環境のみ正確なデータを収集