### PR TITLE
箇条書き・番号付きリストのスタイルを meta-info-viewer-bookmarklet に統一

### DIFF
--- a/src/pages/cheatsheets/sql-cheatsheet/advanced.astro
+++ b/src/pages/cheatsheets/sql-cheatsheet/advanced.astro
@@ -705,7 +705,7 @@ FETCH NEXT 10 ROWS ONLY;</code></pre>
 
   .tip ul {
     margin: 0.5rem 0 0;
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .tip li {

--- a/src/pages/cheatsheets/sql-cheatsheet/basics.astro
+++ b/src/pages/cheatsheets/sql-cheatsheet/basics.astro
@@ -396,7 +396,7 @@ HAVING AVG(price)&gt;= 1000;         -- 平均価格1000円以上</code></pre>
 
   .tip ul {
     margin: 0.5rem 0 0;
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .tip li {

--- a/src/pages/cheatsheets/sql-cheatsheet/manipulation.astro
+++ b/src/pages/cheatsheets/sql-cheatsheet/manipulation.astro
@@ -405,7 +405,7 @@ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
   .tip ul {
     margin: 0.5rem 0 0;
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .tip li {

--- a/src/pages/tips/macos-copy-file-path.astro
+++ b/src/pages/tips/macos-copy-file-path.astro
@@ -53,8 +53,6 @@ const openCommandCode = `open .`;
       <p>
         macOS に標準で備わっている機能。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li>Finder でファイルやフォルダを選択</li>
         <li><strong>Option キーを押しながら右クリック</strong>（または二本指タップ）</li>
@@ -69,8 +67,6 @@ const openCommandCode = `open .`;
       <p>
         直接ターミナルにパスを貼り付けたい場合に便利。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li>ターミナルを開く</li>
         <li>Finder からファイルやフォルダをターミナルのウィンドウにドラッグ&ドロップ</li>
@@ -84,8 +80,6 @@ const openCommandCode = `open .`;
       <p>
         ファイルを選択してショートカットでコピーできる。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li>Finder でファイルやフォルダを選択</li>
         <li><strong>Cmd + Option + C</strong> を押す</li>
@@ -100,8 +94,6 @@ const openCommandCode = `open .`;
       <p>
         より高度なカスタマイズがしたい場合、Automator で独自のサービスを作成できる。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li><strong>Automator</strong> を起動（Applications > Automator）</li>
         <li><strong>クイックアクション</strong> を選択</li>
@@ -121,8 +113,6 @@ const openCommandCode = `open .`;
       <p>
         macOS Monterey 以降では、「ショートカット」アプリでも同様のことができる。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li><strong>ショートカット</strong> アプリを開く</li>
         <li>右上の <strong>+</strong> ボタンをクリック</li>
@@ -257,7 +247,7 @@ const openCommandCode = `open .`;
   }
 
   .article-body ol {
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .article-body code {

--- a/src/pages/tips/meta-info-viewer-bookmarklet.astro
+++ b/src/pages/tips/meta-info-viewer-bookmarklet.astro
@@ -160,9 +160,6 @@ const bookmarkletCode = `javascript:(function(){const id='meta-info-viewer';let 
     margin-bottom: 0.25rem;
   }
 
-  .article-body ul, .article-body ol {
-    padding-left: 2rem;
-  }
 
   .article-body code {
     background: rgba(30, 64, 175, 0.06);

--- a/src/pages/tips/twitter-image-only-filter.astro
+++ b/src/pages/tips/twitter-image-only-filter.astro
@@ -161,8 +161,6 @@ const styleText = \\\`
       <p>
         インストール不要で、ブックマークレットを作成するだけ。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li>Chrome で新しいブックマークを作成（ブックマークバーを右クリック → 「ページを追加」）</li>
         <li>名前を「Twitter 画像のみ」などに設定</li>
@@ -341,7 +339,7 @@ const styleText = \\\`
   }
 
   .article-body ol {
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .article-body code {

--- a/src/pages/tips/twitter-image-original-quality.astro
+++ b/src/pages/tips/twitter-image-original-quality.astro
@@ -40,8 +40,6 @@ const bookmarkletCode = `javascript:(function(){var u=location.href;if(u.match(/
       <p>
         画像の URL の末尾に <code>:orig</code> を追加する。
       </p>
-
-      <h4>手順</h4>
       <ol>
         <li>保存したい画像を右クリック → <strong>画像アドレスをコピー</strong></li>
         <li>コピーした URL をブラウザのアドレスバーに貼り付ける</li>
@@ -220,7 +218,7 @@ https://pbs.twimg.com/media/ABC123xyz?format=jpg&name=orig</code></pre>
   }
 
   .article-body ol {
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .article-body code {

--- a/src/pages/tips/twitter-media-url-extractor.astro
+++ b/src/pages/tips/twitter-media-url-extractor.astro
@@ -292,8 +292,6 @@ openAllMedia();`;
       <p>
         <code>wget</code> を使ってターミナルから一括ダウンロード：
       </p>
-      
-      <h4>手順</h4>
       <ol>
         <li>上記のスクリプトでURLを取得してコピー</li>
         <li>テキストエディタで <code>urls.txt</code> に保存（1行1URL）</li>
@@ -486,7 +484,7 @@ openAllMedia();`;
 
   .note-box ol {
     margin: 0.5rem 0;
-    padding-left: 1.5rem;
+    padding-left: 2rem;
     color: #856404;
   }
 

--- a/src/pages/tips/twitter-text-only-filter.astro
+++ b/src/pages/tips/twitter-text-only-filter.astro
@@ -110,8 +110,6 @@ toggle.addEventListener('change', function() {
       <p>
         インストール不要で、ブックマークレットを作成するだけ。
       </p>
-
-      <h3>手順</h3>
       <ol>
         <li>Chrome で新しいブックマークを作成（ブックマークバーを右クリック → 「ページを追加」）</li>
         <li>名前を「Twitter テキストのみ」などに設定</li>
@@ -247,7 +245,7 @@ toggle.addEventListener('change', function() {
   }
 
   .article-body ol {
-    padding-left: 1.5rem;
+    padding-left: 2rem;
   }
 
   .article-body code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -108,6 +108,11 @@ code {
 .usage-section p {
   color: var(--color-text-muted) !important;
 }
+.article-body ul,
+.article-body ol {
+  padding-left: 2rem;
+}
+
 .article-body code,
 .usage-section code {
   color: var(--color-code) !important;


### PR DESCRIPTION
- ul/ol の padding-left を 2rem に統一（global.css に追加）
- 「手順」見出しを削除し、h3 1. 2. 3. 形式に統一
- Tips ページ・cheatsheet の重複スタイルを整理