### PR TITLE
Tips記事を5本追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://hrstsh.com/
 │
 ├── /tips/ ................. Tips
 │   https://hrstsh.com/tips
-│   (github-pages-trailing-slash-sitemap, meta-info-viewer-bookmarklet, twitter-media-url-extractor, twitter-image-only-filter, twitter-text-only-filter, twitter-hide-reposts, macos-copy-file-path, macos-custom-command, twitter-image-original-quality, youtube-playback-speed, chrome-bookmarklet-favicon, twitter-long-tweet-filter, mac-terminal-customize など)
+│   (youtube-thumbnail-download, twitter-advanced-search-operators, macos-screenshot-settings, page-images-bookmarklet, chrome-copy-all-tabs, github-pages-trailing-slash-sitemap, meta-info-viewer-bookmarklet, twitter-media-url-extractor, twitter-image-only-filter, twitter-text-only-filter, twitter-hide-reposts, macos-copy-file-path, macos-custom-command, twitter-image-original-quality, youtube-playback-speed, chrome-bookmarklet-favicon, twitter-long-tweet-filter, mac-terminal-customize など)
 │
 ├── /privacy ............... プライバシーポリシー・免責事項
 │   https://hrstsh.com/privacy

--- a/src/data/recent.ts
+++ b/src/data/recent.ts
@@ -10,6 +10,11 @@ export interface RecentItem {
 }
 
 export const recentUpdates: RecentItem[] = [
+  { title: 'Chromeで開いている全タブのURLを一括コピーする方法', href: '/tips/chrome-copy-all-tabs/', date: '2026-05-31', showNew: true },
+  { title: 'ページ内の画像を一覧表示・一括取得するブックマークレット', href: '/tips/page-images-bookmarklet/', date: '2026-05-31', showNew: true },
+  { title: 'macOSのスクリーンショットの保存先・形式・影を変更する', href: '/tips/macos-screenshot-settings/', date: '2026-05-30', showNew: true },
+  { title: 'X(Twitter)の検索演算子まとめ（from: / since: / until: / filter:）', href: '/tips/twitter-advanced-search-operators/', date: '2026-05-30', showNew: true },
+  { title: 'YouTubeのサムネイル画像を取得・保存する方法', href: '/tips/youtube-thumbnail-download/', date: '2026-05-30', showNew: true },
   { title: 'X のタイムラインでリポストを非表示にする Chrome 拡張', href: '/tips/twitter-hide-reposts/', date: '2026-03-28', showNew: true },
   { title: 'GitHub Pages + Astro で Search Console のリダイレクトエラーを防ぐ', href: '/tips/github-pages-trailing-slash-sitemap/', date: '2026-03-28', showNew: true },
   { title: 'X（Twitter）検索ツール', href: '/tools/x-search-builder/', date: '2026-03-08', showNew: true },

--- a/src/pages/tips/chrome-copy-all-tabs.astro
+++ b/src/pages/tips/chrome-copy-all-tabs.astro
@@ -1,0 +1,219 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { tipArticle, toIsoDate, faqPage } from '../../utils/jsonLd';
+
+const title = 'Chromeで開いている全タブのURLを一括コピーする方法 - hrの備忘録';
+const description = 'Chromeで開いているタブのURLをまとめてコピーする方法。拡張機能を使わず標準機能だけでコピーする手順と、タブグループを使った整理のコツを紹介。';
+const path = '/tips/chrome-copy-all-tabs';
+const faqItems = [
+  { question: 'Chromeで開いている全タブのURLをコピーするには？', answer: '最初のタブをクリックし、Shiftを押しながら最後のタブをクリックして全タブを選択する。選択したタブを右クリックして「リンクをコピー」を選ぶと、全タブのURLが改行区切りでクリップボードにコピーされる。' },
+  { question: 'タブを範囲選択するショートカットは？', answer: '最初のタブをクリック後、Shift+クリックで連続範囲を選択できる。Cmd（WindowsはCtrl）+クリックなら離れたタブを個別に追加選択できる。' },
+  { question: 'コピーしたURLを後で開き直すには？', answer: 'メモアプリなどに貼り付けて保存しておく。開き直すときは各URLをクリックするか、まとめてアドレスバーに貼り付ける。タブグループとして残したい場合はブックマークの「全てのタブをブックマークに追加」も使える。' },
+];
+const jsonLd = [tipArticle(title.replace(/ - hrの備忘録$/, ''), description, path, toIsoDate('2026.05'), 'tips'), faqPage(faqItems, path)];
+---
+
+<Layout title={title} description={description} jsonLd={jsonLd}>
+  <main>
+    <header class="article-header">
+      <a href="/tips/" class="back-link">← Tips一覧</a>
+      <h1>Chromeで開いている全タブのURLを一括コピーする方法</h1>
+      <p class="article-date">2026.05</p>
+    </header>
+
+    <article class="article-body">
+      <p>
+        調べ物をしていると、タブが大量に開いて収拾がつかなくなる。あとで見返すために URL をまとめて控えておきたい。Chrome の標準機能だけで、開いている全タブの URL を一括コピーできる。拡張機能はいらない。
+      </p>
+
+      <h2>手順</h2>
+      <ol>
+        <li>一番左のタブをクリックする</li>
+        <li><kbd>Shift</kbd> を押しながら一番右のタブをクリックする（間のタブがすべて選択される）</li>
+        <li>選択したタブのどれかを右クリックする</li>
+        <li>メニューから <strong>リンクをコピー</strong> を選ぶ</li>
+      </ol>
+      <p>
+        これで選択したタブの URL が、改行区切りでクリップボードにコピーされる。メモアプリに貼り付ければ、URL の一覧ができあがる。
+      </p>
+
+      <h2>一部のタブだけ選ぶ</h2>
+      <p>
+        全部ではなく、いくつかのタブだけコピーしたいこともある。その場合は選び方を変える。
+      </p>
+      <ul>
+        <li><kbd>Shift</kbd> + クリック … 連続した範囲を選択</li>
+        <li><kbd>Cmd</kbd>（Windows は <kbd>Ctrl</kbd>）+ クリック … 離れたタブを1枚ずつ追加選択</li>
+      </ul>
+      <p>
+        必要なタブだけ選んでから右クリック → <strong>リンクをコピー</strong>。
+      </p>
+
+      <h2>そのまま残しておきたいなら</h2>
+      <p>
+        URL のテキストではなく、あとで開き直せる形で残したいなら、ブックマークにまとめる方法がある。
+      </p>
+      <ul>
+        <li>タブを選択した状態で右クリック → <strong>タブをブックマークに追加</strong></li>
+        <li>フォルダ名を付けて保存すると、フォルダごとまとめて開き直せる</li>
+      </ul>
+
+      <h2>使い分け</h2>
+      <ul>
+        <li>メモやチャットに貼って共有したい → <strong>リンクをコピー</strong></li>
+        <li>あとで同じ状態を復元したい → <strong>タブをブックマークに追加</strong></li>
+      </ul>
+
+      <h2>関連記事</h2>
+      <ul>
+        <li><a href="/tips/meta-info-viewer-bookmarklet/">ページのメタ情報を見やすく表示＆コピーするブックマークレット</a></li>
+        <li><a href="/tips/page-images-bookmarklet/">ページ内の画像を一覧表示・一括取得するブックマークレット</a></li>
+      </ul>
+
+      <h2>よくある質問</h2>
+      <dl class="faq-list">
+        <dt>Chromeで開いている全タブのURLをコピーするには？</dt>
+        <dd>最初のタブをクリックし、Shiftを押しながら最後のタブをクリックして全タブを選択する。選択したタブを右クリックして「リンクをコピー」を選ぶと、全タブのURLが改行区切りでクリップボードにコピーされる。</dd>
+        <dt>タブを範囲選択するショートカットは？</dt>
+        <dd>最初のタブをクリック後、Shift+クリックで連続範囲を選択できる。Cmd（WindowsはCtrl）+クリックなら離れたタブを個別に追加選択できる。</dd>
+        <dt>コピーしたURLを後で開き直すには？</dt>
+        <dd>メモアプリなどに貼り付けて保存しておく。開き直すときは各URLをクリックするか、まとめてアドレスバーに貼り付ける。タブグループとして残したい場合はブックマークの「全てのタブをブックマークに追加」も使える。</dd>
+      </dl>
+
+    </article>
+
+    <footer class="page-footer">
+      <a href="/tips/">Tips一覧に戻る</a> · <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .article-header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .article-body h2 {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.25rem;
+  }
+
+  .article-body h3 {
+    font-size: 1.2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  .article-body p, .article-body ul, .article-body ol {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  .article-body li {
+    margin-bottom: 0.25rem;
+  }
+
+  .article-body ol {
+    padding-left: 2rem;
+  }
+
+  .article-body code {
+    background: rgba(30, 64, 175, 0.06);
+    color: var(--color-code);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  .article-body kbd {
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-size: 0.85em;
+    box-shadow: 0 1px 0 #bbb;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+  }
+
+  .page-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .page-footer a + a {
+    margin-left: 0.5rem;
+  }
+
+  .faq-list dt {
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    color: #333;
+  }
+  .faq-list dd {
+    margin-left: 0;
+    margin-bottom: 0.5rem;
+    color: #444;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/tips/index.astro
+++ b/src/pages/tips/index.astro
@@ -3,6 +3,11 @@ import Layout from '../../layouts/Layout.astro';
 import { itemList } from '../../utils/jsonLd';
 
 const tips = [
+  { name: 'Chromeで開いている全タブのURLを一括コピーする方法', url: '/tips/chrome-copy-all-tabs/', desc: 'タブを範囲選択して右クリック「リンクをコピー」で全URLをまとめて取得。拡張機能不要。' },
+  { name: 'ページ内の画像を一覧表示・一括取得するブックマークレット', url: '/tips/page-images-bookmarklet/', desc: 'ページ内の画像URLをサムネイル付きで一覧表示。外部依存なしの素のJavaScriptで動作。' },
+  { name: 'macOSのスクリーンショットの保存先・形式・影を変更する', url: '/tips/macos-screenshot-settings/', desc: 'defaults write で保存先フォルダ・JPG/PNG・ウィンドウの影を変更する手順。' },
+  { name: 'X(Twitter)の検索演算子まとめ（from: / since: / until: / filter:）', url: '/tips/twitter-advanced-search-operators/', desc: 'アカウント・期間・メディア種別・いいね数で絞り込む検索演算子と組み合わせ例。' },
+  { name: 'YouTubeのサムネイル画像を取得・保存する方法', url: '/tips/youtube-thumbnail-download/', desc: 'img.youtube.com のURLで最大解像度（maxresdefault）まで取得。外部サービス不要。' },
   { name: 'GitHub Pages + Astro で Search Console のリダイレクトエラーを防ぐ（trailing slash とサイトマップ）', url: '/tips/github-pages-trailing-slash-sitemap/', desc: '末尾スラッシュとサイトマップの URL を実配信に揃え、リダイレクトエラーを避ける。' },
   { name: 'ページのメタ情報を見やすく表示＆コピーするブックマークレット', url: '/tips/meta-info-viewer-bookmarklet/', desc: 'title、description、OGタグ、Twitterカードなどを一覧表示し、ワンクリックでコピーできる。' },
   { name: 'X(Twitter)のメディア欄から画像URLを一括取得する方法', url: '/tips/twitter-media-url-extractor/', desc: 'メディアタブの画像URLをまとめて取得。開発者コンソールまたはブックマークレットで実行。' },

--- a/src/pages/tips/macos-screenshot-settings.astro
+++ b/src/pages/tips/macos-screenshot-settings.astro
@@ -1,0 +1,232 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { tipArticle, toIsoDate, faqPage } from '../../utils/jsonLd';
+
+const title = 'macOSのスクリーンショットの保存先・形式・影を変更する - hrの備忘録';
+const description = 'macOSのスクリーンショットをデスクトップ以外に保存したり、PNGをJPGに変えたり、ウィンドウ撮影時の影を消す方法。defaults write コマンドで設定する手順をまとめた。';
+const path = '/tips/macos-screenshot-settings';
+const faqItems = [
+  { question: 'Macのスクリーンショットの保存先を変えるには？', answer: 'ターミナルで defaults write com.apple.screencapture location 保存先のパス を実行し、killall SystemUIServer で反映する。例: defaults write com.apple.screencapture location ~/Pictures/Screenshots' },
+  { question: 'MacのスクリーンショットをJPGで保存するには？', answer: 'defaults write com.apple.screencapture type jpg を実行し、killall SystemUIServer で反映する。png に戻すと元のPNG形式になる。' },
+  { question: 'Macのウィンドウ撮影で付く影を消すには？', answer: 'defaults write com.apple.screencapture disable-shadow -bool true を実行し、killall SystemUIServer で反映する。false に戻すと影が復活する。' },
+];
+const jsonLd = [tipArticle(title.replace(/ - hrの備忘録$/, ''), description, path, toIsoDate('2026.05'), 'tips'), faqPage(faqItems, path)];
+---
+
+<Layout title={title} description={description} jsonLd={jsonLd}>
+  <main>
+    <header class="article-header">
+      <a href="/tips/" class="back-link">← Tips一覧</a>
+      <h1>macOSのスクリーンショットの保存先・形式・影を変更する</h1>
+      <p class="article-date">2026.05</p>
+    </header>
+
+    <article class="article-body">
+      <p>
+        macOS のスクリーンショットは初期設定だとデスクトップに溜まっていく。<code>defaults write</code> コマンドで、保存先・ファイル形式・影の有無を変えられる。撮るたびにデスクトップが散らかる問題はこれで解決する。
+      </p>
+
+      <h2>保存先を変える</h2>
+      <p>
+        専用フォルダに保存するようにする。先にフォルダを作っておく。
+      </p>
+      <pre><code class="language-bash">mkdir -p ~/Pictures/Screenshots
+defaults write com.apple.screencapture location ~/Pictures/Screenshots
+killall SystemUIServer</code></pre>
+      <p>
+        最後の <code>killall SystemUIServer</code> で設定が反映される。これを忘れると変更が効かない。
+      </p>
+
+      <h2>ファイル形式を変える</h2>
+      <p>
+        初期設定は PNG。ファイルサイズを抑えたいなら JPG にする。
+      </p>
+      <pre><code class="language-bash">defaults write com.apple.screencapture type jpg
+killall SystemUIServer</code></pre>
+      <p>
+        指定できる形式は <code>png</code> <code>jpg</code> <code>gif</code> <code>tiff</code> <code>pdf</code> など。PNG に戻すなら <code>type png</code> を実行する。
+      </p>
+
+      <h2>ウィンドウ撮影の影を消す</h2>
+      <p>
+        ウィンドウを撮ると周りに大きな影が付く。これを消すと余白のないスッキリした画像になる。
+      </p>
+      <pre><code class="language-bash">defaults write com.apple.screencapture disable-shadow -bool true
+killall SystemUIServer</code></pre>
+      <p>
+        影を戻すなら <code>-bool false</code> にする。なお、ウィンドウ撮影のときに <kbd>option</kbd> を押しながらクリックすると、設定を変えなくてもその一回だけ影なしで撮れる。
+      </p>
+
+      <h2>ファイル名のプレフィックスを変える</h2>
+      <p>
+        初期設定だと「スクリーンショット 2026-05-31 ...」のような名前になる。先頭の文字列を変えられる。
+      </p>
+      <pre><code class="language-bash">defaults write com.apple.screencapture name "shot"
+killall SystemUIServer</code></pre>
+      <p>
+        これで「shot 2026-05-31 ...」のような名前になる。
+      </p>
+
+      <h2>設定を元に戻す</h2>
+      <p>
+        変更した設定を初期状態に戻すには <code>delete</code> を使う。
+      </p>
+      <pre><code class="language-bash">defaults delete com.apple.screencapture location
+defaults delete com.apple.screencapture type
+defaults delete com.apple.screencapture disable-shadow
+killall SystemUIServer</code></pre>
+
+      <h2>関連記事</h2>
+      <ul>
+        <li><a href="/tips/mac-terminal-customize/">Mac Terminal（zsh）の表示をカスタマイズする</a></li>
+        <li><a href="/tips/macos-copy-file-path/">macOSでファイルパスを一発でターミナルにコピーする</a></li>
+        <li><a href="/tips/macos-custom-command/">Macで自作コマンドを作って登録する方法</a></li>
+      </ul>
+
+      <h2>よくある質問</h2>
+      <dl class="faq-list">
+        <dt>Macのスクリーンショットの保存先を変えるには？</dt>
+        <dd>ターミナルで defaults write com.apple.screencapture location 保存先のパス を実行し、killall SystemUIServer で反映する。例: defaults write com.apple.screencapture location ~/Pictures/Screenshots</dd>
+        <dt>MacのスクリーンショットをJPGで保存するには？</dt>
+        <dd>defaults write com.apple.screencapture type jpg を実行し、killall SystemUIServer で反映する。png に戻すと元のPNG形式になる。</dd>
+        <dt>Macのウィンドウ撮影で付く影を消すには？</dt>
+        <dd>defaults write com.apple.screencapture disable-shadow -bool true を実行し、killall SystemUIServer で反映する。false に戻すと影が復活する。</dd>
+      </dl>
+
+    </article>
+
+    <footer class="page-footer">
+      <a href="/tips/">Tips一覧に戻る</a> · <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .article-header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .article-body h2 {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.25rem;
+  }
+
+  .article-body h3 {
+    font-size: 1.2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  .article-body p, .article-body ul, .article-body ol {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  .article-body li {
+    margin-bottom: 0.25rem;
+  }
+
+  .article-body ol {
+    padding-left: 2rem;
+  }
+
+  .article-body code {
+    background: rgba(30, 64, 175, 0.06);
+    color: var(--color-code);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  .article-body kbd {
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-size: 0.85em;
+    box-shadow: 0 1px 0 #bbb;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+  }
+
+  .page-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .page-footer a + a {
+    margin-left: 0.5rem;
+  }
+
+  .faq-list dt {
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    color: #333;
+  }
+  .faq-list dd {
+    margin-left: 0;
+    margin-bottom: 0.5rem;
+    color: #444;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/tips/page-images-bookmarklet.astro
+++ b/src/pages/tips/page-images-bookmarklet.astro
@@ -1,0 +1,209 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
+import { tipArticle, toIsoDate, faqPage } from '../../utils/jsonLd';
+
+const title = 'ページ内の画像を一覧表示・一括取得するブックマークレット - hrの備忘録';
+const description = '今見ているページの画像URLをまとめて取得するブックマークレット。サムネイル付きで一覧表示し、URLをコピーできる。拡張機能のインストール不要、外部依存なしの素のJavaScriptで動作。';
+const path = '/tips/page-images-bookmarklet';
+const faqItems = [
+  { question: 'ページ内の画像をまとめて保存するには？', answer: 'ブックマークレットを使うと、ページ内の全画像のURLを一覧表示できる。新しいタブにサムネイルとURLの一覧が開くので、必要な画像を保存したりURLをコピーしたりできる。' },
+  { question: 'このブックマークレットは何をしている？', answer: 'document.images でページ内の img 要素を走査し、重複を除いた画像URLを集める。集めたURLを新しいタブにサムネイル付きで一覧表示している。外部サービスには送信していない。' },
+  { question: 'X(Twitter)のメディア欄でも使える？', answer: '使えるが、X はスクロールで画像を遅延読み込みするため、表示済みの画像しか取得できない。X専用の取得方法は別記事で紹介している。' },
+];
+const jsonLd = [tipArticle(title.replace(/ - hrの備忘録$/, ''), description, path, toIsoDate('2026.05'), 'tips'), faqPage(faqItems, path)];
+
+const bookmarkletCode = `javascript:(function(){var imgs=[].slice.call(document.images).map(function(i){return i.currentSrc||i.src;}).filter(function(u,n,a){return u&&a.indexOf(u)===n;});if(!imgs.length){alert('画像が見つかりませんでした');return;}var w=window.open('','_blank');var h='<meta charset=utf-8><title>画像一覧 ('+imgs.length+')</title><body style="font-family:sans-serif;padding:16px"><p>'+imgs.length+' 件の画像</p><textarea style="width:100%;height:120px">'+imgs.join('\\n')+'</textarea>';imgs.forEach(function(u){h+='<div style="margin:8px 0"><a href="'+u+'" target="_blank"><img src="'+u+'" style="max-width:200px;max-height:200px;vertical-align:middle"></a></div>';});w.document.write(h);w.document.close();})();`;
+---
+
+<Layout title={title} description={description} jsonLd={jsonLd}>
+  <main>
+    <header class="article-header">
+      <a href="/tips/" class="back-link">← Tips一覧</a>
+      <h1>ページ内の画像を一覧表示・一括取得するブックマークレット</h1>
+      <p class="article-date">2026.05</p>
+    </header>
+
+    <article class="article-body">
+      <p>
+        保存したい画像がたくさんあるページで、1枚ずつ右クリックして保存するのは面倒。このブックマークレットを使うと、ページ内の画像 URL をまとめて取得して、サムネイル付きの一覧で表示できる。拡張機能のインストールはいらない。
+      </p>
+
+      <h2>ブックマークレット</h2>
+      <p>
+        次のコードを<strong>URL</strong>欄にしたブックマークを作る。
+      </p>
+      <CodeBlock code={bookmarkletCode} language="javascript" />
+
+      <h2>登録手順</h2>
+      <ol>
+        <li>ブックマークバーを右クリック → <strong>ページを追加</strong>（または適当なページをブックマーク）</li>
+        <li>名前を「画像一覧」など分かりやすいものにする</li>
+        <li>URL 欄に上のコードを貼り付けて保存</li>
+      </ol>
+
+      <h2>使い方</h2>
+      <ol>
+        <li>画像を集めたいページを開く</li>
+        <li>作ったブックマークをクリック</li>
+        <li>新しいタブにサムネイルと URL の一覧が開く</li>
+        <li>上部のテキストエリアで URL をまとめてコピー、または各画像を右クリックで保存</li>
+      </ol>
+
+      <h2>仕組み</h2>
+      <p>
+        <code>document.images</code> でページ内の <code>img</code> 要素をすべて取得して、URL を集めてる。同じ URL は除いて、重複しないようにしてる。集めた URL を新しいタブに書き出して、サムネイル付きで並べてるだけ。画像をどこかのサーバーに送ることはない。すべてブラウザの中で完結する。
+      </p>
+
+      <h2>注意</h2>
+      <ul>
+        <li>表示中の画像だけが対象。スクロールしないと読み込まれない画像（遅延読み込み）は、先にスクロールして表示させておく。</li>
+        <li>背景画像（CSS の <code>background-image</code>）は <code>img</code> 要素ではないため取得できない。</li>
+        <li>画像を保存・利用するときは著作権に注意する。</li>
+      </ul>
+
+      <h2>関連記事</h2>
+      <ul>
+        <li><a href="/tips/twitter-media-url-extractor/">X(Twitter)のメディア欄から画像URLを一括取得する方法</a></li>
+        <li><a href="/tips/meta-info-viewer-bookmarklet/">ページのメタ情報を見やすく表示＆コピーするブックマークレット</a></li>
+        <li><a href="/tips/chrome-bookmarklet-favicon/">Chromeのブックマークレットにアイコン（ファビコン）を追加する</a></li>
+      </ul>
+
+      <h2>よくある質問</h2>
+      <dl class="faq-list">
+        <dt>ページ内の画像をまとめて保存するには？</dt>
+        <dd>ブックマークレットを使うと、ページ内の全画像のURLを一覧表示できる。新しいタブにサムネイルとURLの一覧が開くので、必要な画像を保存したりURLをコピーしたりできる。</dd>
+        <dt>このブックマークレットは何をしている？</dt>
+        <dd>document.images でページ内の img 要素を走査し、重複を除いた画像URLを集める。集めたURLを新しいタブにサムネイル付きで一覧表示している。外部サービスには送信していない。</dd>
+        <dt>X(Twitter)のメディア欄でも使える？</dt>
+        <dd>使えるが、X はスクロールで画像を遅延読み込みするため、表示済みの画像しか取得できない。X専用の取得方法は別記事で紹介している。</dd>
+      </dl>
+
+    </article>
+
+    <footer class="page-footer">
+      <a href="/tips/">Tips一覧に戻る</a> · <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .article-header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .article-body h2 {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.25rem;
+  }
+
+  .article-body h3 {
+    font-size: 1.2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  .article-body p, .article-body ul, .article-body ol {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  .article-body li {
+    margin-bottom: 0.25rem;
+  }
+
+  .article-body ol {
+    padding-left: 2rem;
+  }
+
+  .article-body code {
+    background: rgba(30, 64, 175, 0.06);
+    color: var(--color-code);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+  }
+
+  .page-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .page-footer a + a {
+    margin-left: 0.5rem;
+  }
+
+  .faq-list dt {
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    color: #333;
+  }
+  .faq-list dd {
+    margin-left: 0;
+    margin-bottom: 0.5rem;
+    color: #444;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/tips/twitter-advanced-search-operators.astro
+++ b/src/pages/tips/twitter-advanced-search-operators.astro
@@ -1,0 +1,227 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { tipArticle, toIsoDate, faqPage } from '../../utils/jsonLd';
+
+const title = 'X(Twitter)の検索演算子まとめ（from: / since: / until: / filter:） - hrの備忘録';
+const description = 'X(Twitter)の検索で使える演算子のまとめ。特定アカウント・期間・メディア種別での絞り込みや、いいね数の下限指定まで。コピペで使える組み合わせ例も紹介。';
+const path = '/tips/twitter-advanced-search-operators';
+const faqItems = [
+  { question: 'X(Twitter)で特定アカウントの過去ツイートを検索するには？', answer: '検索欄に from:ユーザー名 を入力する。さらに since:2024-01-01 until:2024-12-31 のように日付を足すと、その期間内のツイートだけに絞り込める。' },
+  { question: 'X(Twitter)で画像付きツイートだけを検索するには？', answer: 'キーワードに filter:images を足す。動画なら filter:videos、リンク付きなら filter:links を使う。' },
+  { question: 'いいねが多いツイートだけを検索するには？', answer: 'min_faves:100 のように指定すると、いいねが100以上のツイートだけが表示される。リツイート数なら min_retweets:、リプライ数なら min_replies: を使う。' },
+];
+const jsonLd = [tipArticle(title.replace(/ - hrの備忘録$/, ''), description, path, toIsoDate('2026.05'), 'tips'), faqPage(faqItems, path)];
+---
+
+<Layout title={title} description={description} jsonLd={jsonLd}>
+  <main>
+    <header class="article-header">
+      <a href="/tips/" class="back-link">← Tips一覧</a>
+      <h1>X(Twitter)の検索演算子まとめ（from: / since: / until: / filter:）</h1>
+      <p class="article-date">2026.05</p>
+    </header>
+
+    <article class="article-body">
+      <p>
+        X(Twitter) でキーワードだけ入れて検索しても、目当てのツイートはなかなか出てこない。検索演算子を組み合わせると、アカウント・期間・メディア種別で一気に絞り込める。よく使うものをまとめた。
+      </p>
+
+      <h2>アカウントで絞る</h2>
+      <pre><code class="language-text">from:アカウント名    そのアカウントのツイート
+to:アカウント名      そのアカウント宛のリプライ
+@アカウント名        そのアカウントへの言及を含むツイート</code></pre>
+      <p>
+        <code>from:</code> は <code>@</code> を付けず、ユーザー名（@の後ろの部分）だけを書く。例: <code>from:elonmusk</code>。
+      </p>
+
+      <h2>期間で絞る</h2>
+      <pre><code class="language-text">since:2024-01-01     その日以降のツイート
+until:2024-12-31     その日以前のツイート</code></pre>
+      <p>
+        日付は <code>YYYY-MM-DD</code> 形式。両方を組み合わせると、特定期間のツイートだけに絞れる。「あのアカウントが去年の夏に何か言ってた」を探すときに効く。
+      </p>
+
+      <h2>メディアの種類で絞る</h2>
+      <pre><code class="language-text">filter:images       画像付きツイート
+filter:videos        動画付きツイート
+filter:links         リンク付きツイート
+filter:media         画像・動画どちらか付き
+-filter:replies      リプライを除外
+-filter:retweets     リツイートを除外</code></pre>
+      <p>
+        頭に <code>-</code> を付けると除外になる。<code>-filter:retweets</code> でリツイートを消すと、検索結果がかなり見やすくなる。
+      </p>
+
+      <h2>エンゲージメントで絞る</h2>
+      <pre><code class="language-text">min_faves:100        いいね100以上
+min_retweets:50      リツイート50以上
+min_replies:10       リプライ10以上</code></pre>
+      <p>
+        バズったツイートだけを探したいときに使う。数字を上げるほど結果が絞られる。
+      </p>
+
+      <h2>組み合わせ例</h2>
+      <p>
+        演算子はスペースで区切って並べるだけ。いくつか実用的な組み合わせを挙げる。
+      </p>
+      <pre><code class="language-text">特定アカウントの画像付きツイートだけ:
+from:アカウント名 filter:images
+
+去年バズったツイートを探す:
+キーワード min_faves:1000 since:2024-01-01 until:2024-12-31
+
+リツイートとリプライを除いた本人の発言だけ:
+from:アカウント名 -filter:retweets -filter:replies</code></pre>
+
+      <h2>毎回打つのが面倒なら</h2>
+      <p>
+        条件をフォームから選ぶだけで検索クエリを組み立てられるツールを作ってる。演算子を覚えなくても、画像・ユーザー・期間・いいね数を指定して検索できる。
+      </p>
+      <ul>
+        <li><a href="/tools/x-search-builder/">X（Twitter）検索ツール</a> - 条件を選ぶだけで検索クエリを生成</li>
+      </ul>
+
+      <h2>関連記事</h2>
+      <ul>
+        <li><a href="/tips/twitter-media-url-extractor/">X(Twitter)のメディア欄から画像URLを一括取得する方法</a></li>
+        <li><a href="/tips/twitter-image-original-quality/">X(Twitter)の画像をオリジナル画質で保存する方法</a></li>
+      </ul>
+
+      <h2>よくある質問</h2>
+      <dl class="faq-list">
+        <dt>X(Twitter)で特定アカウントの過去ツイートを検索するには？</dt>
+        <dd>検索欄に from:ユーザー名 を入力する。さらに since:2024-01-01 until:2024-12-31 のように日付を足すと、その期間内のツイートだけに絞り込める。</dd>
+        <dt>X(Twitter)で画像付きツイートだけを検索するには？</dt>
+        <dd>キーワードに filter:images を足す。動画なら filter:videos、リンク付きなら filter:links を使う。</dd>
+        <dt>いいねが多いツイートだけを検索するには？</dt>
+        <dd>min_faves:100 のように指定すると、いいねが100以上のツイートだけが表示される。リツイート数なら min_retweets:、リプライ数なら min_replies: を使う。</dd>
+      </dl>
+
+    </article>
+
+    <footer class="page-footer">
+      <a href="/tips/">Tips一覧に戻る</a> · <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .article-header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .article-body h2 {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.25rem;
+  }
+
+  .article-body h3 {
+    font-size: 1.2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  .article-body p, .article-body ul, .article-body ol {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  .article-body li {
+    margin-bottom: 0.25rem;
+  }
+
+  .article-body ol {
+    padding-left: 2rem;
+  }
+
+  .article-body code {
+    background: rgba(30, 64, 175, 0.06);
+    color: var(--color-code);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+  }
+
+  .page-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .page-footer a + a {
+    margin-left: 0.5rem;
+  }
+
+  .faq-list dt {
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    color: #333;
+  }
+  .faq-list dd {
+    margin-left: 0;
+    margin-bottom: 0.5rem;
+    color: #444;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/tips/youtube-thumbnail-download.astro
+++ b/src/pages/tips/youtube-thumbnail-download.astro
@@ -1,0 +1,229 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { tipArticle, toIsoDate, faqPage } from '../../utils/jsonLd';
+
+const title = 'YouTubeのサムネイル画像を取得・保存する方法 - hrの備忘録';
+const description = 'YouTube動画のサムネイル画像をURLだけで取得する方法。img.youtube.com の形式を使えば、最大解像度（maxresdefault）まで保存できる。動画IDの見つけ方と解像度別のURLを紹介。';
+const path = '/tips/youtube-thumbnail-download';
+const faqItems = [
+  { question: 'YouTubeのサムネイル画像を保存するには？', answer: '動画IDを使って https://img.youtube.com/vi/動画ID/maxresdefault.jpg にアクセスし、右クリックで保存する。動画IDは watch?v= の後ろ、または youtu.be/ の後ろの文字列。' },
+  { question: '最大解像度のサムネイルを取得するには？', answer: 'maxresdefault.jpg を使う。1280×720 の最大サイズで取得できる。ただし古い動画や一部の動画では maxresdefault が存在せず、その場合は hqdefault.jpg（480×360）を使う。' },
+  { question: 'サムネイルを取得するのにアプリやサイトは必要？', answer: '不要。img.youtube.com のURLにアクセスするだけで画像が直接開くので、外部サービスを使わずに保存できる。' },
+];
+const jsonLd = [tipArticle(title.replace(/ - hrの備忘録$/, ''), description, path, toIsoDate('2026.05'), 'tips'), faqPage(faqItems, path)];
+---
+
+<Layout title={title} description={description} jsonLd={jsonLd}>
+  <main>
+    <header class="article-header">
+      <a href="/tips/" class="back-link">← Tips一覧</a>
+      <h1>YouTubeのサムネイル画像を取得・保存する方法</h1>
+      <p class="article-date">2026.05</p>
+    </header>
+
+    <article class="article-body">
+      <p>
+        YouTube のサムネイル画像は、動画ページから直接は保存できない。でも動画 ID を使えば、サムネイルの画像 URL に直接アクセスして保存できる。外部サービスは不要。
+      </p>
+
+      <h2>動画IDを見つける</h2>
+      <p>
+        まず動画 ID を確認する。URL の形式によって場所が違う。
+      </p>
+      <pre><code class="language-text">通常のURL:
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+                              ↑ この dQw4w9WgXcQ が動画ID
+
+短縮URL:
+https://youtu.be/dQw4w9WgXcQ
+                 ↑ youtu.be/ の後ろが動画ID</code></pre>
+      <p>
+        <code>watch?v=</code> の後ろ、または <code>youtu.be/</code> の後ろの 11 文字が動画 ID。後ろに <code>&amp;t=</code> などのパラメータが付いてる場合は、その手前までが ID。
+      </p>
+
+      <h2>サムネイルのURLにアクセスする</h2>
+      <p>
+        動画 ID を次の URL に当てはめてアクセスする。最大解像度のサムネイルが開く。
+      </p>
+      <pre><code class="language-text">https://img.youtube.com/vi/動画ID/maxresdefault.jpg
+
+例:
+https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg</code></pre>
+      <p>
+        開いた画像を右クリック → <strong>名前を付けて画像を保存</strong>。これだけ。
+      </p>
+
+      <h2>解像度別のURL一覧</h2>
+      <p>
+        ファイル名の部分を変えると、取得できる解像度が変わる。
+      </p>
+      <ul>
+        <li><code>maxresdefault.jpg</code> - 最大（1280×720）</li>
+        <li><code>sddefault.jpg</code> - 標準（640×480）</li>
+        <li><code>hqdefault.jpg</code> - 高（480×360）</li>
+        <li><code>mqdefault.jpg</code> - 中（320×180）</li>
+        <li><code>default.jpg</code> - 小（120×90）</li>
+      </ul>
+      <p>
+        基本は <code>maxresdefault.jpg</code> でいい。
+      </p>
+
+      <h2>maxresdefault が無い場合</h2>
+      <p>
+        <code>maxresdefault.jpg</code> は全ての動画にあるわけじゃない。古い動画や、アップロード時に高解像度のサムネイルが作られなかった動画では存在しない。その場合はグレーの仮画像が表示される。
+      </p>
+      <p>
+        表示されなかったら <code>hqdefault.jpg</code> に切り替える。<code>hqdefault.jpg</code> はどの動画にも必ずある。
+      </p>
+
+      <h2>注意</h2>
+      <ul>
+        <li>この URL 形式は YouTube の仕様変更で将来使えなくなる可能性がある。</li>
+        <li>サムネイル画像にも著作権がある。利用するときは権利に注意する。</li>
+        <li>Shorts も同じ動画 ID 形式なので、同じ方法で取得できる。</li>
+      </ul>
+
+      <h2>関連記事</h2>
+      <ul>
+        <li><a href="/tips/youtube-playback-speed/">YouTube動画の再生速度を自由に変更する方法（Chrome）</a></li>
+        <li><a href="/tips/twitter-image-original-quality/">X(Twitter)の画像をオリジナル画質で保存する方法</a></li>
+      </ul>
+
+      <h2>よくある質問</h2>
+      <dl class="faq-list">
+        <dt>YouTubeのサムネイル画像を保存するには？</dt>
+        <dd>動画IDを使って https://img.youtube.com/vi/動画ID/maxresdefault.jpg にアクセスし、右クリックで保存する。動画IDは watch?v= の後ろ、または youtu.be/ の後ろの文字列。</dd>
+        <dt>最大解像度のサムネイルを取得するには？</dt>
+        <dd>maxresdefault.jpg を使う。1280×720 の最大サイズで取得できる。ただし古い動画や一部の動画では maxresdefault が存在せず、その場合は hqdefault.jpg（480×360）を使う。</dd>
+        <dt>サムネイルを取得するのにアプリやサイトは必要？</dt>
+        <dd>不要。img.youtube.com のURLにアクセスするだけで画像が直接開くので、外部サービスを使わずに保存できる。</dd>
+      </dl>
+
+    </article>
+
+    <footer class="page-footer">
+      <a href="/tips/">Tips一覧に戻る</a> · <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    line-height: 1.7;
+  }
+
+  .article-header {
+    margin-bottom: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .article-body h2 {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.25rem;
+  }
+
+  .article-body h3 {
+    font-size: 1.2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: #444;
+  }
+
+  .article-body p, .article-body ul, .article-body ol {
+    margin-bottom: 1rem;
+    color: #444;
+  }
+
+  .article-body li {
+    margin-bottom: 0.25rem;
+  }
+
+  .article-body ol {
+    padding-left: 2rem;
+  }
+
+  .article-body code {
+    background: rgba(30, 64, 175, 0.06);
+    color: var(--color-code);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  pre {
+    background: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+  }
+
+  .page-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e0e0e0;
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: #667eea;
+    text-decoration: none;
+  }
+
+  .page-footer a:hover {
+    text-decoration: underline;
+  }
+
+  .page-footer a + a {
+    margin-left: 0.5rem;
+  }
+
+  .faq-list dt {
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    color: #333;
+  }
+  .faq-list dd {
+    margin-left: 0;
+    margin-bottom: 0.5rem;
+    color: #444;
+    line-height: 1.6;
+  }
+</style>


### PR DESCRIPTION
## 概要

サイト全体を調査し、Tips カテゴリの傾向（X活用・macOS・ブックマークレット）に沿って厳選した新規記事を5本追加しました。

## 追加した記事

| 記事 | 狙い・相互リンク |
|---|---|
| **YouTubeのサムネイル画像を取得・保存する方法** (`youtube-thumbnail-download`) | URLトリック系。既存「X画像オリジナル画質」の兄弟記事 |
| **X(Twitter)の検索演算子まとめ**（from:/since:/filter:）(`twitter-advanced-search-operators`) | サイト最大の軸。自作ツール `x-search-builder` への送客導線つき |
| **macOSのスクリーンショットの保存先・形式・影を変更する** (`macos-screenshot-settings`) | `defaults write` 系。Terminal/ファイルパス記事と相互リンク |
| **ページ内の画像を一覧・一括取得するブックマークレット** (`page-images-bookmarklet`) | ブックマークレット第3弾。外部依存なしの素のJS |
| **Chromeで開いている全タブのURLを一括コピーする方法** (`chrome-copy-all-tabs`) | ブラウザ作業効率。拡張不要 |

## 変更ファイル

- 新規: `src/pages/tips/` 配下に5記事
- 更新: `src/pages/tips/index.astro`（一覧）、`src/data/recent.ts`（最近の更新・NEWバッジ）、`README.md`（サイト構成）

## ルール準拠

- 既存記事のテンプレ（Layout・`article-date`・FAQ・JSON-LD・scoped style）を踏襲
- 文体は既存記事に合わせた常体（`.cursorrules` の「既存ページとの整合」）
- ブックマークレットは `CodeBlock` コンポーネントで `{ }` のビルドエラーを回避

## 検証

- `npm run build` 成功（53ページ）
- 新規5ページが `dist/` に生成、`sitemap-v3.xml` にも反映
- ブックマークレットの出力エンコードを確認

https://claude.ai/code/session_01ETDq4nfMafhHmZenPyf6H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETDq4nfMafhHmZenPyf6H1)_