### PR TITLE
Google AdSense 審査対応（プライバシーポリシー更新 + 広告コード設置）

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -73,6 +73,11 @@ const schemas = jsonLd
         </script>
       </>
     )}
+
+    <!-- Google AdSense (本番環境のみ) -->
+    {isProd && (
+      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9203748382924719" crossorigin="anonymous"></script>
+    )}
   </head>
   <body>
     <div class="layout-main">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -23,22 +23,42 @@ import Layout from '../layouts/Layout.astro';
           をご確認ください。
         </p>
 
-        <h3>2. Cookie について</h3>
+        <h3>2. 広告の配信について</h3>
         <p>
-          当サイトでは、上記のアクセス解析のため Cookie を使用しています。ブラウザの設定で Cookie を無効にすることも可能です。その場合、一部の機能が正常に動作しない可能性があります。
+          当サイトでは、Google が提供する広告配信サービス「Google AdSense」を利用しています。Google AdSense は、ユーザーの興味・関心に基づく広告（インタレストベース広告）を表示するために Cookie を使用します。
+        </p>
+        <p>
+          第三者配信事業者（Google）は Cookie を使用して、ユーザーが当サイトおよびその他のサイトに過去にアクセスした際の情報を基に広告を配信します。これらの Cookie に記録される情報には個人を特定できるものは含まれません。
+        </p>
+        <p>
+          インタレストベース広告を無効にしたい場合は、
+          <a href="https://adssettings.google.com/" target="_blank" rel="noopener noreferrer">Google の広告設定</a>
+          で設定を変更できます。また、
+          <a href="https://optout.aboutads.info/" target="_blank" rel="noopener noreferrer">aboutads.info</a>
+          から第三者配信事業者の Cookie を無効にすることもできます。
+        </p>
+        <p>
+          Google AdSense に関する詳細は
+          <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer">Google の広告に関するポリシー</a>
+          をご確認ください。
         </p>
 
-        <h3>3. 個人情報の取り扱い</h3>
+        <h3>3. Cookie について</h3>
+        <p>
+          当サイトでは、アクセス解析および広告配信のために Cookie を使用しています。ブラウザの設定で Cookie を無効にすることも可能です。その場合、一部の機能が正常に動作しない可能性があります。
+        </p>
+
+        <h3>4. 個人情報の取り扱い</h3>
         <p>
           当サイトは基本的に静的コンテンツを提供しており、フォーム入力等による個人情報の収集は行っていません。お問い合わせは Google フォーム等の外部サービスを利用する場合があり、その際のデータは各サービスのプライバシーポリシーに従います。
         </p>
 
-        <h3>4. 第三者への提供</h3>
+        <h3>5. 第三者への提供</h3>
         <p>
           当サイトで収集した情報を、法令に基づく場合を除き、第三者に提供することはありません。
         </p>
 
-        <h3>5. お問い合わせ</h3>
+        <h3>6. お問い合わせ</h3>
         <p>
           ご質問・ご連絡は<a href="/contact/">お問い合わせページ</a>からお願いします。
         </p>


### PR DESCRIPTION
## 概要

Google AdSense 審査申請に向けた対応をまとめたPRです。

## 変更内容

### 1. プライバシーポリシーに広告配信の記載を追加（`src/pages/privacy.astro`）

「2. 広告の配信について」節を新設。

- Google AdSense を利用していること
- インタレストベース広告のための Cookie 使用
- 記録情報に個人を特定できるものは含まれないこと
- [Google の広告設定](https://adssettings.google.com/) でのオプトアウト方法
- Google の広告ポリシーへのリンク

Cookie の説明文も「アクセス解析**および広告配信**のため」に更新し、節番号（3〜6）を整理。

### 2. AdSense 広告コードを全ページに設置（`src/layouts/Layout.astro`）

`<head>` 内に AdSense スクリプトを追加。Google Analytics と同様に **本番環境のみ** で読み込む形で設置。

```html
<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9203748382924719" crossorigin="anonymous"></script>
```

## マージ後の手順

1. GitHub Actions でデプロイ完了を確認
2. AdSense 管理画面（adsense.google.com）で審査を申請

https://claude.ai/code/session_01ETDq4nfMafhHmZenPyf6H1