### PR TITLE
feat: サイト共通ヘッダー（下スクロールで隠れ・上スクロールで再表示）

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ const isProd = import.meta.env.PROD; // 本番環境判定
 const site = 'https://hrstsh.com';
 const faviconV = '2'; // ファビコン変更時にインクリメント（キャッシュ無効化用）
 const canonical = new URL(Astro.url.pathname || '/', site).href;
+const pathname = Astro.url.pathname;
 const ogImage = image ? (image.startsWith('http') ? image : new URL(image, site).href) : `${site}/favicon.svg`;
 
 const schemas = jsonLd
@@ -80,6 +81,16 @@ const schemas = jsonLd
     )}
   </head>
   <body>
+    <header class="site-header" id="site-header">
+      <div class="site-header-inner">
+        <a href="/" class="site-logo">hrの備忘録</a>
+        <nav class="site-nav">
+          <a href="/tips/" class={pathname.startsWith('/tips') ? 'is-active' : ''}>Tips</a>
+          <a href="/tried/" class={pathname.startsWith('/tried') ? 'is-active' : ''}>Tried</a>
+          <a href="/tools/" class={pathname.startsWith('/tools') ? 'is-active' : ''}>Tools</a>
+        </nav>
+      </div>
+    </header>
     <div class="layout-main">
       <slot />
     </div>
@@ -91,6 +102,25 @@ const schemas = jsonLd
       <p class="footer-copy">© 2026 hrstsh</p>
     </footer>
     <script>
+      // Hide-on-scroll-down, show-on-scroll-up header
+      (function () {
+        const header = document.getElementById('site-header');
+        if (!header) return;
+        let lastY = window.scrollY;
+        window.addEventListener('scroll', function () {
+          const y = window.scrollY;
+          if (y < 60) {
+            header.classList.remove('is-hidden');
+          } else if (y > lastY + 4) {
+            header.classList.add('is-hidden');
+          } else if (lastY > y + 4) {
+            header.classList.remove('is-hidden');
+          }
+          lastY = y;
+        }, { passive: true });
+      })();
+
+      // Image zoom overlay
       document.addEventListener('click', function (e) {
         const img = (e.target as Element).closest('figure img') as HTMLImageElement | null;
         if (!img) return;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,6 +18,7 @@
   --radius-lg: 14px;
   --transition-fast: 0.15s ease;
   --transition-normal: 0.25s ease;
+  --header-height: 48px;
 }
 
 * {
@@ -41,6 +42,7 @@ body {
   line-height: 1.7;
   min-height: 100vh;
   overflow-x: hidden;
+  padding-top: var(--header-height);
   display: flex;
   flex-direction: column;
 }
@@ -168,4 +170,64 @@ figure img {
 @keyframes imgZoomFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }
+}
+
+/* Site header */
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-height);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-border);
+  z-index: 1000;
+  transform: translateY(0);
+  transition: transform 0.25s ease;
+}
+
+.site-header.is-hidden {
+  transform: translateY(-100%);
+}
+
+.site-header-inner {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  font-size: 0.95rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-nav a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.site-nav a:hover,
+.site-nav a.is-active {
+  color: var(--color-primary);
 }


### PR DESCRIPTION
## Summary

- `Layout.astro` に全ページ共通のサイトヘッダーを追加
- ロゴ「hrの備忘録」はトップ（`/`）へのリンク
- ナビリンク: Tips / Tried / Tools（現在のパスに応じてアクティブ表示）
- 下スクロールで隠れ、上スクロールで再表示（`passive` スクロールリスナー、4px しきい値でチャタリング防止）
- ページ上部 60px 以内では常に表示
- `position: fixed` + `backdrop-filter: blur(8px)` で半透明ブラー
- `body { padding-top: var(--header-height) }` でコンテンツが隠れないよう調整

## Test plan

- [x] トップページ・Tips 一覧・Tips 記事・Tried・Tools 各ページでヘッダーが表示されること
- [x] ロゴクリックでトップに遷移すること
- [x] 現在のカテゴリのナビリンクがアクティブ色（紫）になること
- [x] 下スクロールでヘッダーが隠れ、上スクロールで再表示されること
- [x] ページ最上部付近では常に表示されること
- [x] モバイル幅でもレイアウトが崩れないこと

https://claude.ai/code/session_01ETDq4nfMafhHmZenPyf6H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETDq4nfMafhHmZenPyf6H1)_