### PR TITLE
feat: AdSense審査対応 — ads.txt・404・チートシート一覧・運営者情報ページを追加

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9203748382924719, DIRECT, f08c47fec0942fa0

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,143 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="ページが見つかりません - hrの備忘録" description="お探しのページは見つかりませんでした。" noindex={true}>
+  <main>
+    <header class="page-header">
+      <p class="error-code">404</p>
+      <h1>ページが見つかりません</h1>
+      <p class="subtitle">お探しのページは移動または削除された可能性があります</p>
+    </header>
+
+    <section class="suggestions">
+      <h2>こちらからお探しください</h2>
+      <ul class="link-cards">
+        <li>
+          <a href="/" class="link-card">
+            <span class="link-title">トップページ</span>
+            <span class="link-desc">サイト全体のコンテンツ一覧</span>
+          </a>
+        </li>
+        <li>
+          <a href="/tips/" class="link-card">
+            <span class="link-title">Tips</span>
+            <span class="link-desc">ブックマークレット、Chrome拡張、macOSの便利機能など</span>
+          </a>
+        </li>
+        <li>
+          <a href="/tried/" class="link-card">
+            <span class="link-title">やってみた</span>
+            <span class="link-desc">実際に試したことの手記やレポート</span>
+          </a>
+        </li>
+        <li>
+          <a href="/tools/" class="link-card">
+            <span class="link-title">ツール</span>
+            <span class="link-desc">ブラウザ上で動作する便利ツール</span>
+          </a>
+        </li>
+        <li>
+          <a href="/cheatsheets/" class="link-card">
+            <span class="link-title">チートシート</span>
+            <span class="link-desc">Git・Docker・SQL のコマンドリファレンス</span>
+          </a>
+        </li>
+      </ul>
+    </section>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+    line-height: 1.7;
+  }
+
+  .page-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 2px solid transparent;
+    border-image: linear-gradient(90deg, var(--color-primary), var(--color-accent)) 1;
+    text-align: center;
+  }
+
+  .error-code {
+    font-size: 4rem;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.02em;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+  }
+
+  .suggestions h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: var(--color-text);
+  }
+
+  .link-cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .link-card {
+    display: block;
+    padding: 1.25rem 1.5rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition-normal), box-shadow var(--transition-normal),
+      border-color var(--transition-normal);
+  }
+
+  .link-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-hover);
+  }
+
+  .link-title {
+    font-weight: 600;
+    color: var(--color-primary);
+    display: block;
+    margin-bottom: 0.35rem;
+    transition: color var(--transition-fast);
+  }
+
+  .link-card:hover .link-title {
+    color: var(--color-accent);
+  }
+
+  .link-desc {
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
+    display: block;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,172 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="運営者情報 - hrの備忘録" description="hrの備忘録(hrstsh.com)の運営者情報です。サイトの目的や更新方針についてご案内します。">
+  <main>
+    <header class="page-header">
+      <h1>運営者情報</h1>
+      <p class="subtitle">hrの備忘録(hrstsh.com)について</p>
+    </header>
+
+    <article class="article-body">
+      <section>
+        <h2>運営者</h2>
+        <dl class="operator-list">
+          <dt>ハンドル</dt>
+          <dd>hrstsh</dd>
+
+          <dt>サイト名</dt>
+          <dd>hrの備忘録(hrstsh.com)</dd>
+
+          <dt>ホスティング</dt>
+          <dd>GitHub Pages</dd>
+        </dl>
+        <p>
+          Web技術を中心に、日々の開発や調べものの過程で得た知見を記録している個人開発者です。Git・Docker・SQL といった開発ツールを日常的に使っており、ブラウザ上で動くツールや Chrome 拡張機能、ブックマークレットの制作、Python による API 連携の自動化、音声合成基盤の構築など、実際に手を動かして試したことをこのサイトのコンテンツにしています。
+        </p>
+      </section>
+
+      <section>
+        <h2>サイトの目的</h2>
+        <p>
+          このサイトは、自分が「あとで見返したい」と思った情報をまとめた備忘録です。同じことを調べている方の助けになればと、次のコンテンツを公開しています。
+        </p>
+        <ul>
+          <li><a href="/tips/">Tips</a> — ブックマークレットや macOS・ブラウザの便利機能など、すぐ使える小技</li>
+          <li><a href="/tried/">やってみた</a> — 実際に試したことの手記やレポート</li>
+          <li><a href="/tools/">ツール</a> — ブラウザ上で完結する自作ユーティリティ</li>
+          <li><a href="/cheatsheets/">チートシート</a> — Git・Docker・SQL のコマンドリファレンス</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>更新方針</h2>
+        <p>
+          掲載している手順やコードはすべて自分で動作確認したものです。ただし、X(Twitter)や YouTube などの外部サービスに依存する内容は仕様変更で動かなくなることがあるため、気づいた時点で随時更新しています。誤りや動かない手順を見つけた場合は、<a href="/contact/">お問い合わせ</a>からご連絡いただけると助かります。
+        </p>
+      </section>
+    </article>
+
+    <footer class="page-footer">
+      <a href="/">トップに戻る</a>
+      <span class="footer-sep">|</span>
+      <a href="/contact/">お問い合わせ</a>
+      <span class="footer-sep">|</span>
+      <a href="/privacy/">プライバシーポリシー・免責事項</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+    line-height: 1.8;
+  }
+
+  .page-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 2px solid transparent;
+    border-image: linear-gradient(90deg, var(--color-primary), var(--color-accent)) 1;
+  }
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.02em;
+    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+  }
+
+  .article-body {
+    margin-bottom: 2.5rem;
+  }
+
+  .article-body h2 {
+    font-size: 1.35rem;
+    margin: 2rem 0 1rem;
+    color: var(--color-text);
+  }
+
+  .article-body p,
+  .article-body ul {
+    margin-bottom: 1rem;
+  }
+
+  .article-body li {
+    margin-bottom: 0.5rem;
+  }
+
+  .article-body a {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+
+  .article-body a:hover {
+    color: var(--color-accent);
+  }
+
+  .operator-list {
+    display: grid;
+    gap: 0.75rem 1rem;
+    margin: 0 0 1.25rem;
+  }
+
+  .operator-list dt {
+    font-weight: 600;
+    color: var(--color-text-muted);
+    grid-column: 1;
+  }
+
+  .operator-list dd {
+    margin: 0;
+    grid-column: 2;
+  }
+
+  @media (min-width: 480px) {
+    .operator-list {
+      grid-template-columns: auto 1fr;
+    }
+  }
+
+  @media (max-width: 479px) {
+    .operator-list dt {
+      grid-column: 1 / -1;
+    }
+
+    .operator-list dd {
+      grid-column: 1 / -1;
+      padding-left: 0;
+    }
+  }
+
+  .page-footer {
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-border);
+    font-size: 0.95rem;
+  }
+
+  .page-footer a {
+    color: var(--color-primary);
+  }
+
+  .page-footer a:hover {
+    color: var(--color-accent);
+  }
+
+  .footer-sep {
+    margin: 0 0.5rem;
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/pages/cheatsheets/index.astro
+++ b/src/pages/cheatsheets/index.astro
@@ -1,0 +1,152 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { itemList } from '../../utils/jsonLd';
+
+const cheatsheets = [
+  { name: 'Gitコマンドチートシート', url: '/cheatsheets/git-cheatsheet' },
+  { name: 'Dockerコマンドチートシート', url: '/cheatsheets/docker-cheatsheet' },
+  { name: 'SQL基本コマンド集', url: '/cheatsheets/sql-cheatsheet' },
+];
+const jsonLd = itemList('チートシート', 'Git・Docker・SQL のコマンドリファレンス集。基礎から応用まで、実務でよく使うコマンドをカテゴリ別に整理しています。', 'https://hrstsh.com/cheatsheets', cheatsheets);
+---
+
+<Layout title="チートシート - hrの備忘録" description="Git・Docker・SQL のコマンドリファレンス集。基礎から応用まで、実務でよく使うコマンドをカテゴリ別に整理しています。" jsonLd={jsonLd}>
+  <main>
+    <header class="page-header">
+      <h1>チートシート</h1>
+      <p class="subtitle">よく使うコマンドのリファレンス集</p>
+    </header>
+
+    <section class="cheatsheets-list">
+      <h2>チートシート一覧</h2>
+      <ul class="sheet-cards">
+        <li>
+          <a href="/cheatsheets/git-cheatsheet/" class="sheet-card">
+            <span class="sheet-title">Gitコマンドチートシート</span>
+            <span class="sheet-desc">初期設定、ブランチ・マージ、リモート操作、履歴の書き換えなど、基礎から応用まで5編構成で網羅。</span>
+          </a>
+        </li>
+        <li>
+          <a href="/cheatsheets/docker-cheatsheet/" class="sheet-card">
+            <span class="sheet-title">Dockerコマンドチートシート</span>
+            <span class="sheet-desc">基本操作、イメージ管理、コンテナ操作、Docker Compose、Tips まで、実務で使うコマンドを整理。</span>
+          </a>
+        </li>
+        <li>
+          <a href="/cheatsheets/sql-cheatsheet/" class="sheet-card">
+            <span class="sheet-title">SQL基本コマンド集</span>
+            <span class="sheet-desc">SELECT の基礎、JOIN・サブクエリ、データ操作、ウィンドウ関数まで。MySQL/PostgreSQL 対応。</span>
+          </a>
+        </li>
+      </ul>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/">トップに戻る</a>
+    </footer>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+    line-height: 1.7;
+  }
+
+  .page-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 2px solid transparent;
+    border-image: linear-gradient(90deg, var(--color-primary), var(--color-accent)) 1;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.02em;
+    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .subtitle {
+    font-size: 1.1rem;
+    color: var(--color-text-muted);
+  }
+
+  .cheatsheets-list h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: var(--color-text);
+  }
+
+  .sheet-cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .sheet-card {
+    display: block;
+    padding: 1.5rem 1.75rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition-normal), box-shadow var(--transition-normal),
+      border-color var(--transition-normal);
+  }
+
+  .sheet-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-hover);
+  }
+
+  .sheet-title {
+    font-weight: 600;
+    color: var(--color-primary);
+    display: block;
+    margin-bottom: 0.5rem;
+    transition: color var(--transition-fast);
+  }
+
+  .sheet-card:hover .sheet-title {
+    color: var(--color-accent);
+  }
+
+  .sheet-desc {
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
+    display: block;
+    line-height: 1.6;
+  }
+
+  .page-footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-border);
+    text-align: center;
+  }
+
+  .page-footer a {
+    color: var(--color-primary);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color var(--transition-fast);
+  }
+
+  .page-footer a:hover {
+    color: var(--color-accent);
+  }
+</style>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -35,6 +35,9 @@ const CONTACT_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSdQZ2lHjLpBHK
         <dt>ホスティング</dt>
         <dd>GitHub Pages</dd>
       </dl>
+      <p class="operator-more">
+        詳しくは<a href="/about/">運営者情報ページ</a>をご覧ください。
+      </p>
     </section>
 
     <footer class="page-footer">
@@ -149,6 +152,19 @@ const CONTACT_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSdQZ2lHjLpBHK
   }
 
   .operator-list a:hover {
+    color: var(--color-accent);
+  }
+
+  .operator-more {
+    margin-top: 1.25rem;
+  }
+
+  .operator-more a {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+
+  .operator-more a:hover {
     color: var(--color-accent);
   }
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -72,6 +72,11 @@ import Layout from '../layouts/Layout.astro';
           <li>当サイトのコンテンツを参考にした行為により生じた損害について、当サイトは責任を負いません。</li>
         </ul>
       </section>
+
+      <p class="policy-dates">
+        制定日: 2026年2月14日<br />
+        最終改定日: 2026年6月11日
+      </p>
     </article>
 
     <footer class="page-footer">
@@ -143,6 +148,13 @@ import Layout from '../layouts/Layout.astro';
 
   .article-body a:hover {
     color: var(--color-accent);
+  }
+
+  .policy-dates {
+    margin-top: 2rem;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    text-align: right;
   }
 
   .page-footer {


### PR DESCRIPTION
## 概要
Google AdSense 申請中のため、審査通過の観点でサイトを改良する。

## 変更内容
- **public/ads.txt** を配置(`pub-9203748382924719`)
- **カスタム404ページ**(`src/pages/404.astro`)を追加 — noindex 指定、主要セクションへのカードリンク付き
- **チートシート一覧ページ**(`src/pages/cheatsheets/index.astro`)を新設 — 従来404だった `/cheatsheets/` の受け皿。ItemList の構造化データ付き
- **運営者情報ページ**(`src/pages/about.astro`)を新設 — ハンドル・経歴概要・サイトの目的・更新方針。お問い合わせページから誘導リンクを追加
- **プライバシーポリシー**に制定日(2026年2月14日)・最終改定日(2026年6月11日)を追記

ヘッダー/フッターのナビゲーション(Layout.astro)は変更していない。

## 検証
- `npm run build` 成功(57ページ)
- `dist/ads.txt`・`dist/404.html` の生成を確認
- `dist/sitemap-v3.xml`(57 URL)に `/about/` `/cheatsheets/` が自動追加され、404 が混入していないことを確認
- ビルド済みHTMLで内部リンク(お問い合わせ→About、チートシート一覧→各コース)を確認

## デプロイ後の確認事項
- `https://hrstsh.com/ads.txt` が 200 で返ること
- AdSense 管理画面の ads.txt ステータスが「承認済み」になること(反映に数日かかる場合あり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)